### PR TITLE
fix: test_config_loading.py の gemini モデル名を実際の設定値に更新

### DIFF
--- a/packages/core/tests/test_config_loading.py
+++ b/packages/core/tests/test_config_loading.py
@@ -187,7 +187,7 @@ class TestRouteConfigLoadConfig:
         monkeypatch.setenv("AI_ORCHESTRA_DIR", str(REPO_ROOT))
         config = route_config.load_config({"cwd": str(REPO_ROOT)})
         assert config.get("codex", {}).get("model") == "gpt-5.3-codex"
-        assert config.get("gemini", {}).get("model") == "gemini-2.5-pro"
+        assert config.get("gemini", {}).get("model") == "gemini-3.1-pro-preview"
 
     def test_loads_agents_section(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("AI_ORCHESTRA_DIR", str(REPO_ROOT))
@@ -234,4 +234,4 @@ class TestRealConfigFiles:
         assert "agents" in config
         assert config["codex"]["model"] == "gpt-5.3-codex"
         assert config["codex"]["sandbox"]["analysis"] == "read-only"
-        assert config["gemini"]["model"] == "gemini-2.5-pro"
+        assert config["gemini"]["model"] == "gemini-3.1-pro-preview"


### PR DESCRIPTION
## Summary
- `cli-tools.yaml` の `gemini.model` が `gemini-3.1-pro-preview` に更新済みだったが、テストのアサーション値が旧値 `gemini-2.5-pro` のままだったため修正
- `TestRouteConfigLoadConfig::test_loads_via_orchestra_dir` (L190) と `TestRealConfigFiles::test_cli_tools_yaml` (L237) の 2 箇所を更新

Closes #14

## Test plan
- [x] `pytest packages/core/tests/test_config_loading.py` — 全 24 テストパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated system compatibility testing to align with the latest Gemini model version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->