### PR TITLE
fix: release workflowにcontents write権限を追加

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - "v*"
 
+permissions:
+  contents: write
+
 jobs:
   release:
     uses: yoshihiko555/.github/.github/workflows/release.yml@main


### PR DESCRIPTION
## 背景
- v0.2.3 タグ push 後、Release workflow が `startup_failure` で停止し、GitHub Release が自動作成されませんでした
- caller workflow 側に `permissions` 指定がなく、repo の default workflow permission が `read` のため失敗する可能性があります

## 変更内容
- `.github/workflows/release.yml` に `permissions: contents: write` を追加

## 期待効果
- reusable release workflow が release 作成に必要なトークン権限を確実に取得し、タグ push での自動 release 作成が安定する

## 補足
- ユーザー向け機能変更ではないため `CHANGELOG.md` 更新は不要
