### PR TITLE
feat: エスカレーション戦略ルールと探索系エージェントへの反映

### DIFF
--- a/.claude/agents/architecture-reviewer.md
+++ b/.claude/agents/architecture-reviewer.md
@@ -24,6 +24,7 @@ Do NOT hardcode model names or CLI options — always refer to the config file.
 3. model/sandbox/flags の解決順: `agents.<agent-name>.*` → 該当ツールの設定 → フォールバック
 
 ### フォールバックデフォルト（設定ファイルが見つからない場合）
+
 - Tool: claude-direct
 
 ## Role
@@ -59,22 +60,26 @@ gemini -m <model> -p "{architecture review question}" 2>/dev/null
 ## Architecture Checklist
 
 ### Structure
+
 - [ ] Clear layer separation
 - [ ] Appropriate module boundaries
 - [ ] Dependency direction correct
 - [ ] No circular dependencies
 
 ### Patterns
+
 - [ ] Consistent patterns used
 - [ ] Appropriate pattern selection
 - [ ] Pattern violations identified
 
 ### Extensibility
+
 - [ ] Extension points identified
 - [ ] Open-closed principle followed
 - [ ] Configuration over hardcoding
 
 ### Maintainability
+
 - [ ] Reasonable complexity
 - [ ] Clear responsibilities
 - [ ] Documented decisions
@@ -85,22 +90,27 @@ gemini -m <model> -p "{architecture review question}" 2>/dev/null
 
 ```markdown
 ### Critical ({count})
+
 - `{file}:{line}` - **{Issue}**
   {問題の説明 + アーキテクチャへの影響 + 修正案}
 
 ### High ({count})
+
 - `{file}:{line}` - **{Issue}**
   {影響 + 推奨変更}
 
 ### Medium ({count})
+
 - `{file}:{line}` - {1行サマリ}
 
 ### Low ({count})
+
 - `{file}:{line}` - {1行サマリ}
 
 ### Technical Debt
-| Debt | Severity | Effort | Action |
-|------|----------|--------|--------|
+
+| Debt   | Severity     | Effort       | Action   |
+| ------ | ------------ | ------------ | -------- |
 | {debt} | High/Med/Low | High/Med/Low | {action} |
 ```
 
@@ -111,6 +121,14 @@ gemini -m <model> -p "{architecture review question}" 2>/dev/null
 - Consider team capabilities
 - Explicit trade-off documentation
 - Return concise output (main orchestrator has limited context)
+
+## コンテキスト効率
+
+- ファイル探索は Glob → Grep(count) → Grep(files_with_matches) → Grep(content, head_limit) → Read(offset/limit) の段階的絞り込みで行う
+- 対象ファイル 5 個以上の探索ではエスカレーション戦略を徹底、10 個以上はサブエージェント委譲を検討
+- Read は必要な範囲のみ offset/limit で部分読み込み。全文 Read は避ける
+- Bash の cat / grep / find は使用せず、専用ツール（Read / Grep / Glob）を使う
+- 詳細は `escalation-strategy` ルール参照
 
 ## Language
 

--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -24,6 +24,7 @@ Do NOT hardcode model names or CLI options — always refer to the config file.
 3. model/sandbox/flags の解決順: `agents.<agent-name>.*` → 該当ツールの設定 → フォールバック
 
 ### フォールバックデフォルト（設定ファイルが見つからない場合）
+
 - Tool: claude-direct
 
 ## Role
@@ -70,32 +71,20 @@ gemini -m <model> -p "{code review question}" 2>/dev/null
 
 重要度に応じた段階的出力。Medium/Low は 1 行サマリ。
 
-```markdown
-### Critical ({count})
-- `{file}:{line}` - **{Issue}**
-  {問題の説明 + 影響 + 修正案}
-  ```{lang}
-  {コードスニペット}
-  ```
+- `### Critical ({count})` — `- {file}:{line} - **{Issue}** 問題の説明 + 影響 + 修正案 + コードスニペット`
+- `### High ({count})` — `- {file}:{line} - **{Issue}** 問題の説明 + 修正案`
+- `### Medium ({count})` — `- {file}:{line} - {1 行サマリ}`
+- `### Low ({count})` — `- {file}:{line} - {1 行サマリ}`
 
-### High ({count})
-- `{file}:{line}` - **{Issue}**
-  {問題の説明 + 修正案}
-
-### Medium ({count})
-- `{file}:{line}` - {1行サマリ}
-
-### Low ({count})
-- `{file}:{line}` - {1行サマリ}
-```
+Critical/High には言語指定のコードスニペットを添付する（プレーンなインラインコードで記述する）。
 
 ## Severity Levels
 
-| Level | Criteria |
-|-------|----------|
-| Critical | Bugs, security issues, data loss risk |
-| High | Maintainability, performance concerns |
-| Medium/Low | Style, minor improvements |
+| Level      | Criteria                              |
+| ---------- | ------------------------------------- |
+| Critical   | Bugs, security issues, data loss risk |
+| High       | Maintainability, performance concerns |
+| Medium/Low | Style, minor improvements             |
 
 ## Principles
 
@@ -104,6 +93,14 @@ gemini -m <model> -p "{code review question}" 2>/dev/null
 - Suggest specific improvements
 - Acknowledge good practices
 - Return concise output (main orchestrator has limited context)
+
+## コンテキスト効率
+
+- ファイル探索は Glob → Grep(count) → Grep(files_with_matches) → Grep(content, head_limit) → Read(offset/limit) の段階的絞り込みで行う
+- 対象ファイル 5 個以上の探索ではエスカレーション戦略を徹底、10 個以上はサブエージェント委譲を検討
+- Read は必要な範囲のみ offset/limit で部分読み込み。全文 Read は避ける
+- Bash の cat / grep / find は使用せず、専用ツール（Read / Grep / Glob）を使う
+- 詳細は `escalation-strategy` ルール参照
 
 ## Language
 

--- a/.claude/agents/debugger.md
+++ b/.claude/agents/debugger.md
@@ -49,6 +49,7 @@ codex exec --model <codex.model> --sandbox <codex.sandbox.analysis> <codex.flags
 ```
 
 **禁止事項:**
+
 - Codex CLI の使用をスキップしてはならない
 - `[Codex Suggestion]` hook は tool: codex エージェントには適用外 — 無視してよい
 
@@ -89,17 +90,21 @@ gemini -m <gemini.model> -p "{debugging question}" 2>/dev/null
 ## Debug Report: {issue}
 
 ### Issue Summary
+
 {Brief description of the problem}
 
 ### Error Details
+
 \`\`\`
 {Error message / stack trace}
 \`\`\`
 
 ### Root Cause Analysis
+
 {Explanation of why this is happening}
 
 ### Affected Code
+
 - `{file}:{line}` - {description}
 
 ### Proposed Fix
@@ -117,10 +122,12 @@ Rationale: {why this fix}
 Rationale: {why this alternative}
 
 ### Verification Steps
+
 1. {Step to verify fix}
 2. {Additional test to add}
 
 ### Prevention
+
 - {How to prevent similar issues}
 ```
 
@@ -131,6 +138,14 @@ Rationale: {why this alternative}
 - Consider side effects
 - Suggest prevention measures
 - Return concise output (main orchestrator has limited context)
+
+## コンテキスト効率
+
+- ファイル探索は Glob → Grep(count) → Grep(files_with_matches) → Grep(content, head_limit) → Read(offset/limit) の段階的絞り込みで行う
+- 対象ファイル 5 個以上の探索ではエスカレーション戦略を徹底、10 個以上はサブエージェント委譲を検討
+- Read は必要な範囲のみ offset/limit で部分読み込み。全文 Read は避ける
+- Bash の cat / grep / find は使用せず、専用ツール（Read / Grep / Glob）を使う
+- 詳細は `escalation-strategy` ルール参照
 
 ## Language
 

--- a/.claude/agents/general-purpose.md
+++ b/.claude/agents/general-purpose.md
@@ -25,6 +25,7 @@ Do NOT hardcode model names or CLI options — always refer to the config file.
 3. model/sandbox/flags の解決順: `agents.<agent-name>.*` → 該当ツールの設定 → フォールバック
 
 ### フォールバックデフォルト（設定ファイルが見つからない場合）
+
 - Tool: auto
 - Codex model: gpt-5.3-codex
 - Gemini model: (omit -m flag, use CLI default)
@@ -62,6 +63,7 @@ CLI ツール（gemini / codex）は sandbox 内で直接実行する。
 You handle tasks that preserve the main orchestrator's context:
 
 ### Direct Tasks
+
 - File exploration and search
 - Simple implementations
 - Data gathering and summarization
@@ -69,6 +71,7 @@ You handle tasks that preserve the main orchestrator's context:
 - Git operations
 
 ### Delegated Agent Work (Context-Heavy)
+
 - **Codex consultation**: Design decisions, debugging, code review
 - **Gemini research**: Library investigation, codebase analysis, multimodal
 
@@ -93,6 +96,7 @@ codex exec --model <model> --sandbox workspace-write <flags> "{task}" 2>/dev/nul
 ```
 
 **When to call Codex:**
+
 - Design decisions: "How should I structure this?"
 - Debugging: "Why isn't this working?"
 - Trade-offs: "Which approach is better?"
@@ -122,6 +126,7 @@ IMPORTANT: Do not ask any clarifying questions." < /path/to/file 2>/dev/null
 ```
 
 **When to call Gemini:**
+
 - Library research: "Best practices for X"
 - Codebase understanding: "Analyze architecture"
 - Multimodal: "Extract info from this PDF"
@@ -151,17 +156,20 @@ IMPORTANT: Do not ask any clarifying questions." < /dev/null 2>/dev/null
 ## Working Principles
 
 ### Independence
+
 - Complete your assigned task without asking clarifying questions
 - Make reasonable assumptions when details are unclear
 - Report results, not questions
 - **Call Codex/Gemini directly when needed**
 
 ### Efficiency
+
 - Use parallel tool calls when possible
 - Don't over-engineer solutions
 - Focus on the specific task assigned
 
 ### Context Preservation
+
 - **Return concise summaries** (main orchestrator has limited context)
 - Extract key insights, don't dump raw output
 - Bullet points over long paragraphs
@@ -174,18 +182,30 @@ IMPORTANT: Do not ask any clarifying questions." < /dev/null 2>/dev/null
 ## Task: {assigned task}
 
 ## Result
+
 {concise summary of what you accomplished}
 
 ## Key Insights (from Codex/Gemini if consulted)
+
 - {insight 1}
 - {insight 2}
 
 ## Files Changed (if any)
+
 - {file}: {brief change description}
 
 ## Recommendations
+
 - {actionable next steps}
 ```
+
+## コンテキスト効率
+
+- ファイル探索は Glob → Grep(count) → Grep(files_with_matches) → Grep(content, head_limit) → Read(offset/limit) の段階的絞り込みで行う
+- 対象ファイル 5 個以上の探索ではエスカレーション戦略を徹底、10 個以上はサブエージェント委譲を検討
+- Read は必要な範囲のみ offset/limit で部分読み込み。全文 Read は避ける
+- Bash の cat / grep / find は使用せず、専用ツール（Read / Grep / Glob）を使う
+- 詳細は `escalation-strategy` ルール参照
 
 ## Language
 

--- a/.claude/agents/researcher.md
+++ b/.claude/agents/researcher.md
@@ -24,6 +24,7 @@ Do NOT hardcode model names or CLI options — always refer to the config file.
 3. model/sandbox/flags の解決順: `agents.<agent-name>.*` → 該当ツールの設定 → フォールバック
 
 ### フォールバックデフォルト（設定ファイルが見つからない場合）
+
 - Tool: gemini
 - Model: (omit -m flag, use CLI default)
 
@@ -94,18 +95,22 @@ codex exec --model <model> --sandbox <sandbox> <flags> "{research question}" 2>/
 ## Research: {topic}
 
 ### Key Findings
+
 - {Finding 1}
 - {Finding 2}
 - {Finding 3}
 
 ### Recommendations
+
 - {Recommended approach}
 
 ### Sources
+
 - {Source 1}
 - {Source 2}
 
 ### Detailed Notes
+
 {Save to .claude/docs/research/{topic}.md if lengthy}
 ```
 
@@ -116,6 +121,14 @@ codex exec --model <model> --sandbox <sandbox> <flags> "{research question}" 2>/
 - Compare multiple approaches
 - Save detailed output to files, return summary
 - Return concise output (main orchestrator has limited context)
+
+## コンテキスト効率
+
+- ファイル探索は Glob → Grep(count) → Grep(files_with_matches) → Grep(content, head_limit) → Read(offset/limit) の段階的絞り込みで行う
+- 対象ファイル 5 個以上の探索ではエスカレーション戦略を徹底、10 個以上はサブエージェント委譲を検討
+- Read は必要な範囲のみ offset/limit で部分読み込み。全文 Read は避ける
+- Bash の cat / grep / find は使用せず、専用ツール（Read / Grep / Glob）を使う
+- 詳細は `escalation-strategy` ルール参照
 
 ## Language
 

--- a/.claude/rules/escalation-strategy.md
+++ b/.claude/rules/escalation-strategy.md
@@ -1,0 +1,159 @@
+# Context Escalation Policy
+
+**コンテキスト消費を最小化するツール選択のガイドライン。情報取得は「絞り込みファースト」で段階的に行う。**
+
+## 基本原則
+
+Claude Code のコンテキストウィンドウは有限。ツール選択を最適化することで、用途によっては大幅なコンテキスト削減が可能（タスク特性により 50% 以上の削減事例あり）。
+
+- 必要な情報だけを取得し、最小の出力形式から開始する
+- 対象が絞れてから詳細を読む
+- 不明瞭な段階で全文読み込みをしない
+
+## エスカレーション戦略
+
+対象ファイルが特定されていない状態から段階的に絞り込む。必要な情報が得られた段階で停止する。
+
+### Step 1: Glob — ファイル名パターンで候補を集める
+
+ファイル名パターンのみで探せる場合は Glob を使う。パスしか返さないためコンテキストは最小。
+
+```
+Glob: pattern="src/**/*.ts"
+```
+
+### Step 1.5: Grep（`output_mode: "count"`）— マッチ総数を事前把握
+
+検索語のマッチ件数を先に確認し、後続ステップの `head_limit` 設定根拠にする。大量マッチ時のブローアップ防止。
+
+```
+Grep: pattern="foo", output_mode="count"
+```
+
+### Step 2: Grep（`output_mode: "files_with_matches"`）— 該当ファイルだけ取得
+
+マッチしたファイルパスのみ返却。どのファイルを読むべきかを特定する段階。
+
+```
+Grep: pattern="foo", output_mode="files_with_matches"
+```
+
+### Step 3: Grep（`output_mode: "content"`, `head_limit: N`）— 該当行を制限付きで取得
+
+マッチ行周辺の内容を最小限で確認。`head_limit` は Step 1.5 で把握したマッチ数を根拠に決める。
+
+```
+Grep: pattern="foo", output_mode="content", head_limit=20, -C=3
+```
+
+### Step 4: Read（`offset` / `limit` 指定）— 必要な範囲のみ部分読み込み
+
+Grep で特定した行番号を `offset` にそのまま渡し、必要な前後範囲だけを読む。全文読み込みは避ける。
+
+- `offset`: **読み始める行番号（1-indexed）**。Grep の `-n=true` で得た行番号をそのまま指定する。
+- `limit`: 読み取る行数。
+
+```
+# Grep で line=121 にマッチが見つかった場合、少し前から読む
+Read: file_path="...", offset=115, limit=80
+```
+
+## 判断基準ガイドライン
+
+対象ファイル数・サイズに応じて適切な手法を選ぶ。
+
+| 条件                             | 推奨手法                                       |
+| -------------------------------- | ---------------------------------------------- |
+| 対象ファイル数が不明（探索段階） | エスカレーション戦略（Step 1 から順番に）      |
+| 対象ファイル数 5 個以上          | エスカレーション戦略を徹底する                 |
+| 対象ファイル数 3 個以下          | 直接 Read（部分読み込みを優先）                |
+| 対象ファイル数 10 個以上         | サブエージェント委譲でメインコンテキストを保護 |
+| ファイルサイズ 200 行超          | `offset` / `limit` で部分読み込み              |
+| ファイル全体の構造理解が必要     | 直接 Read（目的が明確な場合に限る）            |
+| 大量の検索結果が予想される       | サブエージェント委譲 + 要約返却                |
+
+## アンチパターン
+
+以下の操作はコンテキストを無駄に消費するため避ける。
+
+### 全文 Read の乱用
+
+```
+# Bad: いきなり全文 Read
+Read: file_path="src/large_module.ts"  # 1000 行超のファイル
+
+# Good: Grep で対象行を特定 → その行番号を offset にそのまま渡して部分 Read
+Grep: pattern="handleClick", output_mode="content", -n=true  # 例: line 121 にヒット
+Read: file_path="src/large_module.ts", offset=115, limit=60  # 少し前から 60 行読む
+```
+
+### `output_mode: "content"` の乱用
+
+マッチ件数を把握せずに content モードを使うと、数百行の出力がコンテキストに流れ込む。
+
+```
+# Bad: 件数不明のまま content モード
+Grep: pattern="log", output_mode="content"  # 数百マッチの可能性
+
+# Good: まず count で把握し、head_limit を設定
+Grep: pattern="log", output_mode="count"
+Grep: pattern="log", output_mode="content", head_limit=30
+```
+
+### `head_limit` 未指定
+
+`output_mode: "content"` で `head_limit` を指定しないのは危険。デフォルト 250 行まで返却される。
+
+```
+# Bad
+Grep: pattern="import", output_mode="content"
+
+# Good
+Grep: pattern="import", output_mode="content", head_limit=50
+```
+
+### 全ファイル Read による一括確認
+
+複数ファイルを順に全文 Read するのは最悪手。サブエージェント委譲で要約を得る。
+
+```
+# Bad: 10 ファイルを順に全文 Read
+for f in files:
+    Read: file_path=f
+
+# Good: サブエージェント委譲
+Task(subagent_type="general-purpose", prompt="次の 10 ファイルから X を抽出し要約を返せ: ...")
+```
+
+### Bash での `cat` / `head` / `tail` / `find` / `grep`
+
+専用ツール（Read / Glob / Grep）を使うべき操作を Bash に流すと、出力制御ができずコンテキストを食う。
+
+```
+# Bad: Bash 経由で全文出力
+Bash: command="cat src/large_module.ts"
+Bash: command="find . -name '*.ts'"
+Bash: command="grep -rn 'foo' src/"
+
+# Good: 専用ツールを使う
+Read: file_path="src/large_module.ts", offset=1, limit=100
+Glob: pattern="**/*.ts"
+Grep: pattern="foo", path="src", output_mode="files_with_matches"
+```
+
+## サブエージェント委譲の判断
+
+次のいずれかに該当する場合はサブエージェント経由で実行する:
+
+- 対象ファイル 10 個以上
+- 検索結果が数百行以上になる見込み
+- 外部 CLI（Codex / Gemini）の大きな出力を伴う
+- 複数の独立した調査を並列で進めたい
+
+サブエージェントには **要約形式での返却** を指示し、メインコンテキストには要点のみを残す。
+
+## 運用補足
+
+- このポリシーは全スキル・全エージェントが共有する最低基準。
+- 個別スキル内の手順書で上書きが必要な場合は、明示的に理由を記載する。
+- 既存ルール（`context-sharing`, `orchestra-usage`）と整合する。

--- a/.codex/rules/escalation-strategy.md
+++ b/.codex/rules/escalation-strategy.md
@@ -1,0 +1,159 @@
+# Context Escalation Policy
+
+**コンテキスト消費を最小化するツール選択のガイドライン。情報取得は「絞り込みファースト」で段階的に行う。**
+
+## 基本原則
+
+Claude Code のコンテキストウィンドウは有限。ツール選択を最適化することで、用途によっては大幅なコンテキスト削減が可能（タスク特性により 50% 以上の削減事例あり）。
+
+- 必要な情報だけを取得し、最小の出力形式から開始する
+- 対象が絞れてから詳細を読む
+- 不明瞭な段階で全文読み込みをしない
+
+## エスカレーション戦略
+
+対象ファイルが特定されていない状態から段階的に絞り込む。必要な情報が得られた段階で停止する。
+
+### Step 1: Glob — ファイル名パターンで候補を集める
+
+ファイル名パターンのみで探せる場合は Glob を使う。パスしか返さないためコンテキストは最小。
+
+```
+Glob: pattern="src/**/*.ts"
+```
+
+### Step 1.5: Grep（`output_mode: "count"`）— マッチ総数を事前把握
+
+検索語のマッチ件数を先に確認し、後続ステップの `head_limit` 設定根拠にする。大量マッチ時のブローアップ防止。
+
+```
+Grep: pattern="foo", output_mode="count"
+```
+
+### Step 2: Grep（`output_mode: "files_with_matches"`）— 該当ファイルだけ取得
+
+マッチしたファイルパスのみ返却。どのファイルを読むべきかを特定する段階。
+
+```
+Grep: pattern="foo", output_mode="files_with_matches"
+```
+
+### Step 3: Grep（`output_mode: "content"`, `head_limit: N`）— 該当行を制限付きで取得
+
+マッチ行周辺の内容を最小限で確認。`head_limit` は Step 1.5 で把握したマッチ数を根拠に決める。
+
+```
+Grep: pattern="foo", output_mode="content", head_limit=20, -C=3
+```
+
+### Step 4: Read（`offset` / `limit` 指定）— 必要な範囲のみ部分読み込み
+
+Grep で特定した行番号を `offset` にそのまま渡し、必要な前後範囲だけを読む。全文読み込みは避ける。
+
+- `offset`: **読み始める行番号（1-indexed）**。Grep の `-n=true` で得た行番号をそのまま指定する。
+- `limit`: 読み取る行数。
+
+```
+# Grep で line=121 にマッチが見つかった場合、少し前から読む
+Read: file_path="...", offset=115, limit=80
+```
+
+## 判断基準ガイドライン
+
+対象ファイル数・サイズに応じて適切な手法を選ぶ。
+
+| 条件                             | 推奨手法                                       |
+| -------------------------------- | ---------------------------------------------- |
+| 対象ファイル数が不明（探索段階） | エスカレーション戦略（Step 1 から順番に）      |
+| 対象ファイル数 5 個以上          | エスカレーション戦略を徹底する                 |
+| 対象ファイル数 3 個以下          | 直接 Read（部分読み込みを優先）                |
+| 対象ファイル数 10 個以上         | サブエージェント委譲でメインコンテキストを保護 |
+| ファイルサイズ 200 行超          | `offset` / `limit` で部分読み込み              |
+| ファイル全体の構造理解が必要     | 直接 Read（目的が明確な場合に限る）            |
+| 大量の検索結果が予想される       | サブエージェント委譲 + 要約返却                |
+
+## アンチパターン
+
+以下の操作はコンテキストを無駄に消費するため避ける。
+
+### 全文 Read の乱用
+
+```
+# Bad: いきなり全文 Read
+Read: file_path="src/large_module.ts"  # 1000 行超のファイル
+
+# Good: Grep で対象行を特定 → その行番号を offset にそのまま渡して部分 Read
+Grep: pattern="handleClick", output_mode="content", -n=true  # 例: line 121 にヒット
+Read: file_path="src/large_module.ts", offset=115, limit=60  # 少し前から 60 行読む
+```
+
+### `output_mode: "content"` の乱用
+
+マッチ件数を把握せずに content モードを使うと、数百行の出力がコンテキストに流れ込む。
+
+```
+# Bad: 件数不明のまま content モード
+Grep: pattern="log", output_mode="content"  # 数百マッチの可能性
+
+# Good: まず count で把握し、head_limit を設定
+Grep: pattern="log", output_mode="count"
+Grep: pattern="log", output_mode="content", head_limit=30
+```
+
+### `head_limit` 未指定
+
+`output_mode: "content"` で `head_limit` を指定しないのは危険。デフォルト 250 行まで返却される。
+
+```
+# Bad
+Grep: pattern="import", output_mode="content"
+
+# Good
+Grep: pattern="import", output_mode="content", head_limit=50
+```
+
+### 全ファイル Read による一括確認
+
+複数ファイルを順に全文 Read するのは最悪手。サブエージェント委譲で要約を得る。
+
+```
+# Bad: 10 ファイルを順に全文 Read
+for f in files:
+    Read: file_path=f
+
+# Good: サブエージェント委譲
+Task(subagent_type="general-purpose", prompt="次の 10 ファイルから X を抽出し要約を返せ: ...")
+```
+
+### Bash での `cat` / `head` / `tail` / `find` / `grep`
+
+専用ツール（Read / Glob / Grep）を使うべき操作を Bash に流すと、出力制御ができずコンテキストを食う。
+
+```
+# Bad: Bash 経由で全文出力
+Bash: command="cat src/large_module.ts"
+Bash: command="find . -name '*.ts'"
+Bash: command="grep -rn 'foo' src/"
+
+# Good: 専用ツールを使う
+Read: file_path="src/large_module.ts", offset=1, limit=100
+Glob: pattern="**/*.ts"
+Grep: pattern="foo", path="src", output_mode="files_with_matches"
+```
+
+## サブエージェント委譲の判断
+
+次のいずれかに該当する場合はサブエージェント経由で実行する:
+
+- 対象ファイル 10 個以上
+- 検索結果が数百行以上になる見込み
+- 外部 CLI（Codex / Gemini）の大きな出力を伴う
+- 複数の独立した調査を並列で進めたい
+
+サブエージェントには **要約形式での返却** を指示し、メインコンテキストには要点のみを残す。
+
+## 運用補足
+
+- このポリシーは全スキル・全エージェントが共有する最低基準。
+- 個別スキル内の手順書で上書きが必要な場合は、明示的に理由を記載する。
+- 既存ルール（`context-sharing`, `orchestra-usage`）と整合する。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `context_files` key in package manifests for context file ownership (#36)
 - `required_package` field in CONTEXT_SPECS for data-driven distribution (#36)
 - `escalation-strategy` ルール: コンテキスト節約のためのツール選択ガイドライン（Glob → Grep count → Grep files → Grep content → Read offset/limit の段階的絞り込み、判断基準、アンチパターン）を `core` パッケージに追加 (#9)
+- 探索系サブエージェント定義にコンテキスト効率セクションを追加: `general-purpose`, `researcher`, `code-reviewer`, `debugger`, `architecture-reviewer` (#11)
 - `audit` パッケージ: `route-audit` + `cli-logging` を統合した統一イベントログ監査基盤 (#38)
   - 統一スキーマ v1（`v`, `ts`, `sid`, `eid`, `type`, `tid`, `ptid`, `aid`, `ctx`, `data`）
   - セッション単位のログローテーション（`sessions/{session_id}.jsonl`）

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `pr-standards` ポリシー: PR 作成ルールを `pr-create` と `issue-fix` で共通化
 - `context_files` key in package manifests for context file ownership (#36)
 - `required_package` field in CONTEXT_SPECS for data-driven distribution (#36)
+- `escalation-strategy` ルール: コンテキスト節約のためのツール選択ガイドライン（Glob → Grep count → Grep files → Grep content → Read offset/limit の段階的絞り込み、判断基準、アンチパターン）を `core` パッケージに追加 (#9)
 - `audit` パッケージ: `route-audit` + `cli-logging` を統合した統一イベントログ監査基盤 (#38)
   - 統一スキーマ v1（`v`, `ts`, `sid`, `eid`, `type`, `tid`, `ptid`, `aid`, `ctx`, `data`）
   - セッション単位のログローテーション（`sessions/{session_id}.jsonl`）

--- a/facets/compositions/rules/escalation-strategy.yaml
+++ b/facets/compositions/rules/escalation-strategy.yaml
@@ -1,0 +1,8 @@
+# escalation-strategy ルールのファセット構成定義
+name: escalation-strategy
+description: コンテキスト節約のためのツール選択エスカレーション戦略
+type: rule
+
+# 参照するポリシー（facets/policies/ から解決）
+policies:
+  - context-escalation

--- a/facets/policies/context-escalation.md
+++ b/facets/policies/context-escalation.md
@@ -1,0 +1,159 @@
+# Context Escalation Policy
+
+**コンテキスト消費を最小化するツール選択のガイドライン。情報取得は「絞り込みファースト」で段階的に行う。**
+
+## 基本原則
+
+Claude Code のコンテキストウィンドウは有限。ツール選択を最適化することで、用途によっては大幅なコンテキスト削減が可能（タスク特性により 50% 以上の削減事例あり）。
+
+- 必要な情報だけを取得し、最小の出力形式から開始する
+- 対象が絞れてから詳細を読む
+- 不明瞭な段階で全文読み込みをしない
+
+## エスカレーション戦略
+
+対象ファイルが特定されていない状態から段階的に絞り込む。必要な情報が得られた段階で停止する。
+
+### Step 1: Glob — ファイル名パターンで候補を集める
+
+ファイル名パターンのみで探せる場合は Glob を使う。パスしか返さないためコンテキストは最小。
+
+```
+Glob: pattern="src/**/*.ts"
+```
+
+### Step 1.5: Grep（`output_mode: "count"`）— マッチ総数を事前把握
+
+検索語のマッチ件数を先に確認し、後続ステップの `head_limit` 設定根拠にする。大量マッチ時のブローアップ防止。
+
+```
+Grep: pattern="foo", output_mode="count"
+```
+
+### Step 2: Grep（`output_mode: "files_with_matches"`）— 該当ファイルだけ取得
+
+マッチしたファイルパスのみ返却。どのファイルを読むべきかを特定する段階。
+
+```
+Grep: pattern="foo", output_mode="files_with_matches"
+```
+
+### Step 3: Grep（`output_mode: "content"`, `head_limit: N`）— 該当行を制限付きで取得
+
+マッチ行周辺の内容を最小限で確認。`head_limit` は Step 1.5 で把握したマッチ数を根拠に決める。
+
+```
+Grep: pattern="foo", output_mode="content", head_limit=20, -C=3
+```
+
+### Step 4: Read（`offset` / `limit` 指定）— 必要な範囲のみ部分読み込み
+
+Grep で特定した行番号を `offset` にそのまま渡し、必要な前後範囲だけを読む。全文読み込みは避ける。
+
+- `offset`: **読み始める行番号（1-indexed）**。Grep の `-n=true` で得た行番号をそのまま指定する。
+- `limit`: 読み取る行数。
+
+```
+# Grep で line=121 にマッチが見つかった場合、少し前から読む
+Read: file_path="...", offset=115, limit=80
+```
+
+## 判断基準ガイドライン
+
+対象ファイル数・サイズに応じて適切な手法を選ぶ。
+
+| 条件                             | 推奨手法                                       |
+| -------------------------------- | ---------------------------------------------- |
+| 対象ファイル数が不明（探索段階） | エスカレーション戦略（Step 1 から順番に）      |
+| 対象ファイル数 5 個以上          | エスカレーション戦略を徹底する                 |
+| 対象ファイル数 3 個以下          | 直接 Read（部分読み込みを優先）                |
+| 対象ファイル数 10 個以上         | サブエージェント委譲でメインコンテキストを保護 |
+| ファイルサイズ 200 行超          | `offset` / `limit` で部分読み込み              |
+| ファイル全体の構造理解が必要     | 直接 Read（目的が明確な場合に限る）            |
+| 大量の検索結果が予想される       | サブエージェント委譲 + 要約返却                |
+
+## アンチパターン
+
+以下の操作はコンテキストを無駄に消費するため避ける。
+
+### 全文 Read の乱用
+
+```
+# Bad: いきなり全文 Read
+Read: file_path="src/large_module.ts"  # 1000 行超のファイル
+
+# Good: Grep で対象行を特定 → その行番号を offset にそのまま渡して部分 Read
+Grep: pattern="handleClick", output_mode="content", -n=true  # 例: line 121 にヒット
+Read: file_path="src/large_module.ts", offset=115, limit=60  # 少し前から 60 行読む
+```
+
+### `output_mode: "content"` の乱用
+
+マッチ件数を把握せずに content モードを使うと、数百行の出力がコンテキストに流れ込む。
+
+```
+# Bad: 件数不明のまま content モード
+Grep: pattern="log", output_mode="content"  # 数百マッチの可能性
+
+# Good: まず count で把握し、head_limit を設定
+Grep: pattern="log", output_mode="count"
+Grep: pattern="log", output_mode="content", head_limit=30
+```
+
+### `head_limit` 未指定
+
+`output_mode: "content"` で `head_limit` を指定しないのは危険。デフォルト 250 行まで返却される。
+
+```
+# Bad
+Grep: pattern="import", output_mode="content"
+
+# Good
+Grep: pattern="import", output_mode="content", head_limit=50
+```
+
+### 全ファイル Read による一括確認
+
+複数ファイルを順に全文 Read するのは最悪手。サブエージェント委譲で要約を得る。
+
+```
+# Bad: 10 ファイルを順に全文 Read
+for f in files:
+    Read: file_path=f
+
+# Good: サブエージェント委譲
+Task(subagent_type="general-purpose", prompt="次の 10 ファイルから X を抽出し要約を返せ: ...")
+```
+
+### Bash での `cat` / `head` / `tail` / `find` / `grep`
+
+専用ツール（Read / Glob / Grep）を使うべき操作を Bash に流すと、出力制御ができずコンテキストを食う。
+
+```
+# Bad: Bash 経由で全文出力
+Bash: command="cat src/large_module.ts"
+Bash: command="find . -name '*.ts'"
+Bash: command="grep -rn 'foo' src/"
+
+# Good: 専用ツールを使う
+Read: file_path="src/large_module.ts", offset=1, limit=100
+Glob: pattern="**/*.ts"
+Grep: pattern="foo", path="src", output_mode="files_with_matches"
+```
+
+## サブエージェント委譲の判断
+
+次のいずれかに該当する場合はサブエージェント経由で実行する:
+
+- 対象ファイル 10 個以上
+- 検索結果が数百行以上になる見込み
+- 外部 CLI（Codex / Gemini）の大きな出力を伴う
+- 複数の独立した調査を並列で進めたい
+
+サブエージェントには **要約形式での返却** を指示し、メインコンテキストには要点のみを残す。
+
+## 運用補足
+
+- このポリシーは全スキル・全エージェントが共有する最低基準。
+- 個別スキル内の手順書で上書きが必要な場合は、明示的に理由を記載する。
+- 既存ルール（`context-sharing`, `orchestra-usage`）と整合する。

--- a/packages/agent-routing/agents/architecture-reviewer.md
+++ b/packages/agent-routing/agents/architecture-reviewer.md
@@ -24,6 +24,7 @@ Do NOT hardcode model names or CLI options — always refer to the config file.
 3. model/sandbox/flags の解決順: `agents.<agent-name>.*` → 該当ツールの設定 → フォールバック
 
 ### フォールバックデフォルト（設定ファイルが見つからない場合）
+
 - Tool: claude-direct
 
 ## Role
@@ -59,22 +60,26 @@ gemini -m <model> -p "{architecture review question}" 2>/dev/null
 ## Architecture Checklist
 
 ### Structure
+
 - [ ] Clear layer separation
 - [ ] Appropriate module boundaries
 - [ ] Dependency direction correct
 - [ ] No circular dependencies
 
 ### Patterns
+
 - [ ] Consistent patterns used
 - [ ] Appropriate pattern selection
 - [ ] Pattern violations identified
 
 ### Extensibility
+
 - [ ] Extension points identified
 - [ ] Open-closed principle followed
 - [ ] Configuration over hardcoding
 
 ### Maintainability
+
 - [ ] Reasonable complexity
 - [ ] Clear responsibilities
 - [ ] Documented decisions
@@ -85,22 +90,27 @@ gemini -m <model> -p "{architecture review question}" 2>/dev/null
 
 ```markdown
 ### Critical ({count})
+
 - `{file}:{line}` - **{Issue}**
   {問題の説明 + アーキテクチャへの影響 + 修正案}
 
 ### High ({count})
+
 - `{file}:{line}` - **{Issue}**
   {影響 + 推奨変更}
 
 ### Medium ({count})
+
 - `{file}:{line}` - {1行サマリ}
 
 ### Low ({count})
+
 - `{file}:{line}` - {1行サマリ}
 
 ### Technical Debt
-| Debt | Severity | Effort | Action |
-|------|----------|--------|--------|
+
+| Debt   | Severity     | Effort       | Action   |
+| ------ | ------------ | ------------ | -------- |
 | {debt} | High/Med/Low | High/Med/Low | {action} |
 ```
 
@@ -111,6 +121,14 @@ gemini -m <model> -p "{architecture review question}" 2>/dev/null
 - Consider team capabilities
 - Explicit trade-off documentation
 - Return concise output (main orchestrator has limited context)
+
+## コンテキスト効率
+
+- ファイル探索は Glob → Grep(count) → Grep(files_with_matches) → Grep(content, head_limit) → Read(offset/limit) の段階的絞り込みで行う
+- 対象ファイル 5 個以上の探索ではエスカレーション戦略を徹底、10 個以上はサブエージェント委譲を検討
+- Read は必要な範囲のみ offset/limit で部分読み込み。全文 Read は避ける
+- Bash の cat / grep / find は使用せず、専用ツール（Read / Grep / Glob）を使う
+- 詳細は `escalation-strategy` ルール参照
 
 ## Language
 

--- a/packages/agent-routing/agents/code-reviewer.md
+++ b/packages/agent-routing/agents/code-reviewer.md
@@ -24,6 +24,7 @@ Do NOT hardcode model names or CLI options — always refer to the config file.
 3. model/sandbox/flags の解決順: `agents.<agent-name>.*` → 該当ツールの設定 → フォールバック
 
 ### フォールバックデフォルト（設定ファイルが見つからない場合）
+
 - Tool: claude-direct
 
 ## Role
@@ -70,32 +71,20 @@ gemini -m <model> -p "{code review question}" 2>/dev/null
 
 重要度に応じた段階的出力。Medium/Low は 1 行サマリ。
 
-```markdown
-### Critical ({count})
-- `{file}:{line}` - **{Issue}**
-  {問題の説明 + 影響 + 修正案}
-  ```{lang}
-  {コードスニペット}
-  ```
+- `### Critical ({count})` — `- {file}:{line} - **{Issue}** 問題の説明 + 影響 + 修正案 + コードスニペット`
+- `### High ({count})` — `- {file}:{line} - **{Issue}** 問題の説明 + 修正案`
+- `### Medium ({count})` — `- {file}:{line} - {1 行サマリ}`
+- `### Low ({count})` — `- {file}:{line} - {1 行サマリ}`
 
-### High ({count})
-- `{file}:{line}` - **{Issue}**
-  {問題の説明 + 修正案}
-
-### Medium ({count})
-- `{file}:{line}` - {1行サマリ}
-
-### Low ({count})
-- `{file}:{line}` - {1行サマリ}
-```
+Critical/High には言語指定のコードスニペットを添付する（プレーンなインラインコードで記述する）。
 
 ## Severity Levels
 
-| Level | Criteria |
-|-------|----------|
-| Critical | Bugs, security issues, data loss risk |
-| High | Maintainability, performance concerns |
-| Medium/Low | Style, minor improvements |
+| Level      | Criteria                              |
+| ---------- | ------------------------------------- |
+| Critical   | Bugs, security issues, data loss risk |
+| High       | Maintainability, performance concerns |
+| Medium/Low | Style, minor improvements             |
 
 ## Principles
 
@@ -104,6 +93,14 @@ gemini -m <model> -p "{code review question}" 2>/dev/null
 - Suggest specific improvements
 - Acknowledge good practices
 - Return concise output (main orchestrator has limited context)
+
+## コンテキスト効率
+
+- ファイル探索は Glob → Grep(count) → Grep(files_with_matches) → Grep(content, head_limit) → Read(offset/limit) の段階的絞り込みで行う
+- 対象ファイル 5 個以上の探索ではエスカレーション戦略を徹底、10 個以上はサブエージェント委譲を検討
+- Read は必要な範囲のみ offset/limit で部分読み込み。全文 Read は避ける
+- Bash の cat / grep / find は使用せず、専用ツール（Read / Grep / Glob）を使う
+- 詳細は `escalation-strategy` ルール参照
 
 ## Language
 

--- a/packages/agent-routing/agents/debugger.md
+++ b/packages/agent-routing/agents/debugger.md
@@ -49,6 +49,7 @@ codex exec --model <codex.model> --sandbox <codex.sandbox.analysis> <codex.flags
 ```
 
 **禁止事項:**
+
 - Codex CLI の使用をスキップしてはならない
 - `[Codex Suggestion]` hook は tool: codex エージェントには適用外 — 無視してよい
 
@@ -89,17 +90,21 @@ gemini -m <gemini.model> -p "{debugging question}" 2>/dev/null
 ## Debug Report: {issue}
 
 ### Issue Summary
+
 {Brief description of the problem}
 
 ### Error Details
+
 \`\`\`
 {Error message / stack trace}
 \`\`\`
 
 ### Root Cause Analysis
+
 {Explanation of why this is happening}
 
 ### Affected Code
+
 - `{file}:{line}` - {description}
 
 ### Proposed Fix
@@ -117,10 +122,12 @@ Rationale: {why this fix}
 Rationale: {why this alternative}
 
 ### Verification Steps
+
 1. {Step to verify fix}
 2. {Additional test to add}
 
 ### Prevention
+
 - {How to prevent similar issues}
 ```
 
@@ -131,6 +138,14 @@ Rationale: {why this alternative}
 - Consider side effects
 - Suggest prevention measures
 - Return concise output (main orchestrator has limited context)
+
+## コンテキスト効率
+
+- ファイル探索は Glob → Grep(count) → Grep(files_with_matches) → Grep(content, head_limit) → Read(offset/limit) の段階的絞り込みで行う
+- 対象ファイル 5 個以上の探索ではエスカレーション戦略を徹底、10 個以上はサブエージェント委譲を検討
+- Read は必要な範囲のみ offset/limit で部分読み込み。全文 Read は避ける
+- Bash の cat / grep / find は使用せず、専用ツール（Read / Grep / Glob）を使う
+- 詳細は `escalation-strategy` ルール参照
 
 ## Language
 

--- a/packages/agent-routing/agents/general-purpose.md
+++ b/packages/agent-routing/agents/general-purpose.md
@@ -25,6 +25,7 @@ Do NOT hardcode model names or CLI options — always refer to the config file.
 3. model/sandbox/flags の解決順: `agents.<agent-name>.*` → 該当ツールの設定 → フォールバック
 
 ### フォールバックデフォルト（設定ファイルが見つからない場合）
+
 - Tool: auto
 - Codex model: gpt-5.3-codex
 - Gemini model: (omit -m flag, use CLI default)
@@ -62,6 +63,7 @@ CLI ツール（gemini / codex）は sandbox 内で直接実行する。
 You handle tasks that preserve the main orchestrator's context:
 
 ### Direct Tasks
+
 - File exploration and search
 - Simple implementations
 - Data gathering and summarization
@@ -69,6 +71,7 @@ You handle tasks that preserve the main orchestrator's context:
 - Git operations
 
 ### Delegated Agent Work (Context-Heavy)
+
 - **Codex consultation**: Design decisions, debugging, code review
 - **Gemini research**: Library investigation, codebase analysis, multimodal
 
@@ -93,6 +96,7 @@ codex exec --model <model> --sandbox workspace-write <flags> "{task}" 2>/dev/nul
 ```
 
 **When to call Codex:**
+
 - Design decisions: "How should I structure this?"
 - Debugging: "Why isn't this working?"
 - Trade-offs: "Which approach is better?"
@@ -122,6 +126,7 @@ IMPORTANT: Do not ask any clarifying questions." < /path/to/file 2>/dev/null
 ```
 
 **When to call Gemini:**
+
 - Library research: "Best practices for X"
 - Codebase understanding: "Analyze architecture"
 - Multimodal: "Extract info from this PDF"
@@ -151,17 +156,20 @@ IMPORTANT: Do not ask any clarifying questions." < /dev/null 2>/dev/null
 ## Working Principles
 
 ### Independence
+
 - Complete your assigned task without asking clarifying questions
 - Make reasonable assumptions when details are unclear
 - Report results, not questions
 - **Call Codex/Gemini directly when needed**
 
 ### Efficiency
+
 - Use parallel tool calls when possible
 - Don't over-engineer solutions
 - Focus on the specific task assigned
 
 ### Context Preservation
+
 - **Return concise summaries** (main orchestrator has limited context)
 - Extract key insights, don't dump raw output
 - Bullet points over long paragraphs
@@ -174,18 +182,30 @@ IMPORTANT: Do not ask any clarifying questions." < /dev/null 2>/dev/null
 ## Task: {assigned task}
 
 ## Result
+
 {concise summary of what you accomplished}
 
 ## Key Insights (from Codex/Gemini if consulted)
+
 - {insight 1}
 - {insight 2}
 
 ## Files Changed (if any)
+
 - {file}: {brief change description}
 
 ## Recommendations
+
 - {actionable next steps}
 ```
+
+## コンテキスト効率
+
+- ファイル探索は Glob → Grep(count) → Grep(files_with_matches) → Grep(content, head_limit) → Read(offset/limit) の段階的絞り込みで行う
+- 対象ファイル 5 個以上の探索ではエスカレーション戦略を徹底、10 個以上はサブエージェント委譲を検討
+- Read は必要な範囲のみ offset/limit で部分読み込み。全文 Read は避ける
+- Bash の cat / grep / find は使用せず、専用ツール（Read / Grep / Glob）を使う
+- 詳細は `escalation-strategy` ルール参照
 
 ## Language
 

--- a/packages/agent-routing/agents/researcher.md
+++ b/packages/agent-routing/agents/researcher.md
@@ -24,6 +24,7 @@ Do NOT hardcode model names or CLI options — always refer to the config file.
 3. model/sandbox/flags の解決順: `agents.<agent-name>.*` → 該当ツールの設定 → フォールバック
 
 ### フォールバックデフォルト（設定ファイルが見つからない場合）
+
 - Tool: gemini
 - Model: (omit -m flag, use CLI default)
 
@@ -94,18 +95,22 @@ codex exec --model <model> --sandbox <sandbox> <flags> "{research question}" 2>/
 ## Research: {topic}
 
 ### Key Findings
+
 - {Finding 1}
 - {Finding 2}
 - {Finding 3}
 
 ### Recommendations
+
 - {Recommended approach}
 
 ### Sources
+
 - {Source 1}
 - {Source 2}
 
 ### Detailed Notes
+
 {Save to .claude/docs/research/{topic}.md if lengthy}
 ```
 
@@ -116,6 +121,14 @@ codex exec --model <model> --sandbox <sandbox> <flags> "{research question}" 2>/
 - Compare multiple approaches
 - Save detailed output to files, return summary
 - Return concise output (main orchestrator has limited context)
+
+## コンテキスト効率
+
+- ファイル探索は Glob → Grep(count) → Grep(files_with_matches) → Grep(content, head_limit) → Read(offset/limit) の段階的絞り込みで行う
+- 対象ファイル 5 個以上の探索ではエスカレーション戦略を徹底、10 個以上はサブエージェント委譲を検討
+- Read は必要な範囲のみ offset/limit で部分読み込み。全文 Read は避ける
+- Bash の cat / grep / find は使用せず、専用ツール（Read / Grep / Glob）を使う
+- 詳細は `escalation-strategy` ルール参照
 
 ## Language
 

--- a/packages/core/manifest.json
+++ b/packages/core/manifest.json
@@ -31,9 +31,21 @@
     "hooks/update-working-context.py",
     "hooks/cleanup-session-context.py"
   ],
-  "skills": ["preflight", "startproject", "checkpointing", "task-state", "design"],
+  "skills": [
+    "preflight",
+    "startproject",
+    "checkpointing",
+    "task-state",
+    "design"
+  ],
   "agents": [],
-  "rules": ["config-loading", "coding-principles", "task-memory-usage", "context-sharing"],
+  "rules": [
+    "config-loading",
+    "coding-principles",
+    "task-memory-usage",
+    "context-sharing",
+    "escalation-strategy"
+  ],
   "scripts": [],
   "config": ["config/task-memory.yaml"]
 }


### PR DESCRIPTION
Closes #9
Closes #11

## Summary

- `escalation-strategy` ルールを `core` パッケージに新規追加。コンテキスト節約のためのツール選択ガイドライン（段階的絞り込み / 判断基準 / アンチパターン）を文書化 (#9)
- 探索系サブエージェント 5 種（`general-purpose`, `researcher`, `code-reviewer`, `debugger`, `architecture-reviewer`）に「コンテキスト効率」セクションを追加し、新ルールを参照 (#11)
- 付随修正: `code-reviewer.md` の Output Format セクションがネストされたコードフェンスで破損していた問題を解消（prettier と相性が悪いネスト構造を箇条書き形式に再構成）

## Testing

- [x] `pytest -q`: 1127 passed, 17 skipped
- [x] `ruff check .`: All checks passed
- [x] `facet build --name escalation-strategy --target {claude,codex}` で生成物を確認
- [x] code-reviewer サブエージェントによるレビューで Critical / High の指摘を解消

## Release Note

- ユーザー向け変更点:
  - `escalation-strategy` ルールが `core` パッケージ経由で全プロジェクトに配布される（SessionStart の sync-orchestra 時に自動展開）
  - 既存の探索系エージェント定義に効率化ガイドラインが組み込まれ、サブエージェント内部の挙動にも反映される
- `CHANGELOG.md` の `Unreleased` に両 Issue の変更を追記済み

## Checklist

- [x] PR タイトルが GitHub Release にそのまま載っても読める
- [x] 適切なラベルを付けた (`enhancement`)
- [x] ユーザー向け変更があるため `CHANGELOG.md` の `Unreleased` を更新した

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 内部設定ファイルを更新し、エスカレーション戦略機能に対応しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->