### PR TITLE
feat(hooks): Claude Code の新 hook イベント (PreCompact / InstructionsLoaded / Stop) に対応

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   - 新規イベント: `session_start`, `session_end`, `subagent_start`, `subagent_end`
   - トレース ID によるプロンプト→ルーティング→ツール実行の呼び出しチェーン追跡
   - CLI 呼び出しのエラー分類（timeout, auth, rate_limit 等）と生レスポンス記録
+- 新しい hook イベントへの対応（Claude Code の最新 hook API に合わせた拡張）
+  - `core/precompact-dump.py`: PreCompact イベントで working-context と Plans.md を
+    `.claude/context/shared/precompact-{timestamp}.md` に退避（圧縮前の重要情報退避）
+  - `audit/audit-instructions-loaded.py`: InstructionsLoaded イベントで CLAUDE.md / ルール等の
+    ロード状況（`load_reason`, `file_path`, `globs`）を audit v1 ログに記録
+  - `quality-gates/turn-end-summary.py`: Stop イベントでターン終了サマリーを注入
+    （編集ファイル数、Plans.md の WIP/TODO/blocked 件数、lint 未実行リマインダー）
+  - audit 統一スキーマに `instructions_loaded`, `turn_end`, `precompact` イベント型を追加
 
 ### Changed
 

--- a/packages/audit/hooks/audit-instructions-loaded.py
+++ b/packages/audit/hooks/audit-instructions-loaded.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""InstructionsLoaded hook: CLAUDE.md / rules などの読み込みを監査ログに記録する。
+
+Claude Code が instructions ファイル (CLAUDE.md, .claude/rules/*.md 等) を
+ロードしたタイミングで発火し、どのファイルが・なぜロードされたかを
+audit v1 ログに追記する。
+
+目的:
+- Codex Context Gap 問題の観測（どのルールがどの CLI に渡っているか可視化）
+- デバッグ時にロード順序と load_reason を後追いできるようにする
+
+副作用:
+- stdout への JSON 出力は行わない（観測専用）。
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+_hook_dir = os.path.dirname(os.path.abspath(__file__))
+if _hook_dir not in sys.path:
+    sys.path.insert(0, _hook_dir)
+
+_orchestra_dir = os.environ.get("AI_ORCHESTRA_DIR", "")
+if _orchestra_dir:
+    _core_hooks = os.path.join(_orchestra_dir, "packages", "core", "hooks")
+    if os.path.isdir(_core_hooks) and _core_hooks not in sys.path:
+        sys.path.insert(0, _core_hooks)
+    _audit_hooks = os.path.join(_orchestra_dir, "packages", "audit", "hooks")
+    if os.path.isdir(_audit_hooks) and _audit_hooks not in sys.path:
+        sys.path.insert(0, _audit_hooks)
+
+from event_logger import (
+    emit_event,
+    load_trace_state,
+    resolve_project_root_from_hook_data,
+)
+from hook_common import (
+    load_package_config,
+    read_hook_input,
+    safe_hook_execution,
+)
+
+# プロジェクトルートからの相対化を試みるベースパス候補
+_PATH_KEYS = ("file_path", "trigger_file_path", "parent_file_path")
+
+
+def _relativize(path: str, project_dir: str) -> str:
+    """project_dir 起点の相対パスに変換する。範囲外なら元の文字列を返す。"""
+    if not path:
+        return path
+    try:
+        return os.path.relpath(path, project_dir)
+    except ValueError:
+        return path
+
+
+def build_payload(data: dict, project_dir: str) -> dict:
+    """instructions_loaded イベントのペイロードを組み立てる。
+
+    Args:
+        data: hook stdin 入力。
+        project_dir: 解決済みプロジェクトルート。
+
+    Returns:
+        emit_event に渡すペイロード辞書。
+    """
+    payload: dict = {
+        "load_reason": str(data.get("load_reason") or ""),
+        "memory_type": str(data.get("memory_type") or ""),
+    }
+    for key in _PATH_KEYS:
+        value = data.get(key)
+        if isinstance(value, str) and value:
+            payload[key] = _relativize(value, project_dir)
+
+    globs = data.get("globs")
+    if isinstance(globs, list) and globs:
+        payload["globs"] = [str(g) for g in globs[:10]]
+
+    return payload
+
+
+@safe_hook_execution
+def main() -> None:
+    """InstructionsLoaded hook のエントリポイント。"""
+    data = read_hook_input()
+
+    project_dir = resolve_project_root_from_hook_data(data)
+
+    flags = load_package_config("audit", "audit-flags.json", project_dir)
+    feature_cfg = (flags.get("features") or {}).get("instructions_loaded") or {}
+    # デフォルトで有効。明示的に disabled にされた場合のみ停止する。
+    if feature_cfg.get("enabled") is False:
+        return
+
+    session_id = str(data.get("session_id") or "")
+    if not session_id:
+        # セッション確立前（InstructionsLoaded は極めて早期に発火する）は書き込まない
+        return
+
+    payload = build_payload(data, project_dir)
+
+    trace = load_trace_state(project_dir)
+    tid = trace.get("tid") or ""
+
+    emit_event(
+        "instructions_loaded",
+        payload,
+        session_id=session_id,
+        tid=tid,
+        project_dir=project_dir,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/audit/hooks/event_logger.py
+++ b/packages/audit/hooks/event_logger.py
@@ -41,6 +41,9 @@ EVENT_TYPES = frozenset(
         "subagent_start",
         "subagent_end",
         "quality_gate",
+        "instructions_loaded",
+        "turn_end",
+        "precompact",
     }
 )
 

--- a/packages/audit/manifest.json
+++ b/packages/audit/manifest.json
@@ -12,7 +12,8 @@
       { "file": "audit-cli.py", "matcher": "Bash" }
     ],
     "SubagentStart": ["audit-subagent-start.py"],
-    "SubagentStop": ["audit-subagent-end.py"]
+    "SubagentStop": ["audit-subagent-end.py"],
+    "InstructionsLoaded": ["audit-instructions-loaded.py"]
   },
   "files": [
     "hooks/event_logger.py",
@@ -22,7 +23,8 @@
     "hooks/audit-route.py",
     "hooks/audit-cli.py",
     "hooks/audit-subagent-start.py",
-    "hooks/audit-subagent-end.py"
+    "hooks/audit-subagent-end.py",
+    "hooks/audit-instructions-loaded.py"
   ],
   "skills": [],
   "agents": [],

--- a/packages/audit/tests/test_audit_instructions_loaded.py
+++ b/packages/audit/tests/test_audit_instructions_loaded.py
@@ -1,0 +1,142 @@
+"""audit-instructions-loaded.py のユニットテスト。"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+from tests.module_loader import REPO_ROOT, load_module
+
+# AI_ORCHESTRA_DIR は worktree 切り替え時に stale なコピーを指す可能性があるため、
+# テスト中は必ず REPO_ROOT で上書きしてから hook を import する（sub-hook 内の
+# sys.path 挿入がテスト対象の .py を参照するように強制する）。
+os.environ["AI_ORCHESTRA_DIR"] = str(REPO_ROOT)
+
+_audit_hooks = str(REPO_ROOT / "packages" / "audit" / "hooks")
+_core_hooks = str(REPO_ROOT / "packages" / "core" / "hooks")
+for p in [_audit_hooks, _core_hooks]:
+    if p not in sys.path:
+        sys.path.insert(0, p)
+
+# event_logger を先に load_module しておくと、hook が `from event_logger import`
+# したときに同じインスタンスを再利用する（EVENT_TYPES の不一致を防ぐ）。
+event_logger = load_module("event_logger", "packages/audit/hooks/event_logger.py")
+audit_instructions = load_module(
+    "audit_instructions_loaded",
+    "packages/audit/hooks/audit-instructions-loaded.py",
+)
+
+
+class TestRelativize:
+    """`_relativize` のテスト。"""
+
+    def test_relativizes_path_under_project(self, tmp_path: Path) -> None:
+        """project_dir 配下のパスが相対化されることを確認する。"""
+        inside = str(tmp_path / "sub" / "rule.md")
+        relative = audit_instructions._relativize(inside, str(tmp_path))
+        assert relative == os.path.join("sub", "rule.md")
+
+    def test_returns_original_for_empty_path(self) -> None:
+        """空文字は空文字のまま返ることを確認する。"""
+        assert audit_instructions._relativize("", "/tmp") == ""
+
+
+class TestBuildPayload:
+    """`build_payload` のテスト。"""
+
+    def test_includes_core_fields(self, tmp_path: Path) -> None:
+        """load_reason / memory_type が必ず含まれることを確認する。"""
+        data = {"load_reason": "session_start", "memory_type": "user"}
+        payload = audit_instructions.build_payload(data, str(tmp_path))
+        assert payload["load_reason"] == "session_start"
+        assert payload["memory_type"] == "user"
+
+    def test_relativizes_all_path_keys(self, tmp_path: Path) -> None:
+        """file_path / trigger_file_path / parent_file_path が相対化されることを確認する。"""
+        data = {
+            "load_reason": "path_glob_match",
+            "file_path": str(tmp_path / "a" / "CLAUDE.md"),
+            "trigger_file_path": str(tmp_path / "b" / "trigger.py"),
+            "parent_file_path": str(tmp_path / "c" / "parent.md"),
+        }
+        payload = audit_instructions.build_payload(data, str(tmp_path))
+        assert payload["file_path"] == os.path.join("a", "CLAUDE.md")
+        assert payload["trigger_file_path"] == os.path.join("b", "trigger.py")
+        assert payload["parent_file_path"] == os.path.join("c", "parent.md")
+
+    def test_globs_truncated_to_10(self, tmp_path: Path) -> None:
+        """globs は 10 件までに制限されることを確認する。"""
+        data = {"load_reason": "x", "globs": [f"*.md{i}" for i in range(15)]}
+        payload = audit_instructions.build_payload(data, str(tmp_path))
+        assert len(payload["globs"]) == 10
+
+
+class TestMain:
+    """`main` のエンドツーエンド動作を確認する。"""
+
+    def _invoke(self, payload: dict, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(payload)))
+        audit_instructions.main()
+
+    def test_writes_event_to_session_log(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """session_id ありの入力でセッションログに書き込まれることを確認する。"""
+        project_dir = tmp_path
+        (project_dir / ".claude").mkdir()
+
+        payload = {
+            "session_id": "sess-a",
+            "cwd": str(project_dir),
+            "load_reason": "session_start",
+            "file_path": str(project_dir / "CLAUDE.md"),
+            "memory_type": "project",
+        }
+        self._invoke(payload, monkeypatch)
+
+        log_path = event_logger.get_session_log_path("sess-a", str(project_dir))
+        assert os.path.exists(log_path)
+        with open(log_path, encoding="utf-8") as f:
+            lines = f.readlines()
+        assert len(lines) == 1
+        record = json.loads(lines[0])
+        assert record["type"] == "instructions_loaded"
+        assert record["data"]["load_reason"] == "session_start"
+        assert record["data"]["file_path"] == "CLAUDE.md"
+
+    def test_skips_without_session_id(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """session_id が無い場合はログが出力されないことを確認する。"""
+        (tmp_path / ".claude").mkdir()
+        payload = {"cwd": str(tmp_path), "load_reason": "session_start"}
+        self._invoke(payload, monkeypatch)
+
+        sessions_dir = tmp_path / ".claude" / "logs" / "audit" / "sessions"
+        assert not sessions_dir.exists() or not any(sessions_dir.iterdir())
+
+    def test_disabled_flag_skips_logging(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """audit-flags.json で features.instructions_loaded.enabled=false のとき書き込まれないことを確認する。"""
+        project_dir = tmp_path
+        config_dir = project_dir / ".claude" / "config" / "audit"
+        config_dir.mkdir(parents=True)
+        (config_dir / "audit-flags.json").write_text(
+            json.dumps({"features": {"instructions_loaded": {"enabled": False}}})
+        )
+
+        payload = {
+            "session_id": "sess-b",
+            "cwd": str(project_dir),
+            "load_reason": "session_start",
+        }
+        self._invoke(payload, monkeypatch)
+
+        log_path = event_logger.get_session_log_path("sess-b", str(project_dir))
+        assert not os.path.exists(log_path)

--- a/packages/core/hooks/context_store.py
+++ b/packages/core/hooks/context_store.py
@@ -89,6 +89,16 @@ def _sanitize_agent_id(agent_id: str) -> str:
     return safe[:_MAX_AGENT_ID_LEN]
 
 
+def get_shared_dir(project_dir: str) -> str:
+    """`.claude/context/shared/` の絶対パスを返す公開 API。
+
+    CLI 間で共有される作業コンテキスト置き場のパスを取得する。
+    このディレクトリは存在しないこともあるため、書き込み側が必要に応じて
+    `Path(...).mkdir(parents=True, exist_ok=True)` を呼ぶこと。
+    """
+    return _shared_dir(project_dir)
+
+
 def get_project_dir(data: dict) -> str:
     """hook 入力からプロジェクトディレクトリを取得する。
 

--- a/packages/core/hooks/precompact-dump.py
+++ b/packages/core/hooks/precompact-dump.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""PreCompact hook: コンテキスト圧縮前に重要情報を Markdown ファイルへ退避する。
+
+Claude Code がコンテキスト圧縮を実行する直前に発火する。
+圧縮で失われる可能性のある作業コンテキスト・Plans.md スナップショットを
+`.claude/context/shared/precompact-{timestamp}.md` に書き出す。
+
+退避内容:
+- working-context.json の modified_files / current_phase / decisions
+- Plans.md 本体（そのままコピー）
+- セッション ID と圧縮トリガー種別（manual / auto）
+
+副作用:
+- stdout への JSON 出力は行わない（観測専用）。失敗しても exit 0 を返し、
+  圧縮フローをブロックしない。
+"""
+
+from __future__ import annotations
+
+import datetime
+import os
+import sys
+from pathlib import Path
+
+_hook_dir = os.path.dirname(os.path.abspath(__file__))
+if _hook_dir not in sys.path:
+    sys.path.insert(0, _hook_dir)
+
+# audit package が有効なら event_logger を読み込む（監査ログへの統一書き込み）。
+# 未インストール / import 失敗時は監査出力をスキップし、Markdown ダンプのみ行う。
+_orchestra_dir = os.environ.get("AI_ORCHESTRA_DIR", "")
+if _orchestra_dir:
+    _audit_hooks = os.path.join(_orchestra_dir, "packages", "audit", "hooks")
+    if os.path.isdir(_audit_hooks) and _audit_hooks not in sys.path:
+        sys.path.insert(0, _audit_hooks)
+
+from context_store import get_project_dir, get_shared_dir, read_working_context
+from hook_common import read_hook_input, safe_hook_execution
+
+try:
+    from event_logger import emit_event as _emit_event  # type: ignore[import-not-found]
+except ImportError:  # pragma: no cover - audit 未導入時のフォールバック
+    _emit_event = None  # type: ignore[assignment]
+
+# 保存するダンプファイルの最大数（古いものから削除）
+MAX_DUMP_FILES = 20
+
+
+def _now_stamp() -> str:
+    """ファイル名用のタイムスタンプを返す（UTC, コロン無し）。"""
+    return datetime.datetime.now(datetime.UTC).strftime("%Y%m%dT%H%M%SZ")
+
+
+def _read_plans(project_dir: str) -> str:
+    """Plans.md の内容を読み込む。存在しない場合は空文字を返す。"""
+    plans_path = os.path.join(project_dir, ".claude", "Plans.md")
+    try:
+        with open(plans_path, encoding="utf-8") as f:
+            return f.read()
+    except OSError:
+        return ""
+
+
+def _format_working_context(ctx: dict) -> str:
+    """working-context.json を人間可読な Markdown に整形する。"""
+    if not ctx:
+        return "_(empty)_\n"
+
+    lines: list[str] = []
+    for key in ("current_phase", "updated_at"):
+        value = ctx.get(key)
+        if value:
+            lines.append(f"- **{key}**: {value}")
+
+    modified = ctx.get("modified_files")
+    if isinstance(modified, list) and modified:
+        lines.append(f"- **modified_files** ({len(modified)}):")
+        for path in modified[-30:]:
+            lines.append(f"  - `{path}`")
+
+    decisions = ctx.get("decisions")
+    if isinstance(decisions, list) and decisions:
+        lines.append("- **decisions**:")
+        for item in decisions[-10:]:
+            lines.append(f"  - {item}")
+
+    # 既知キー以外もダンプしておく（将来の拡張に耐える）
+    known = {"current_phase", "updated_at", "modified_files", "decisions"}
+    extras = {k: v for k, v in ctx.items() if k not in known}
+    if extras:
+        lines.append("- **other**:")
+        for k, v in extras.items():
+            lines.append(f"  - `{k}`: {v!r}")
+
+    return "\n".join(lines) + "\n"
+
+
+def build_dump_text(
+    *,
+    session_id: str,
+    trigger: str,
+    working_ctx: dict,
+    plans_text: str,
+) -> str:
+    """圧縮退避用の Markdown 本文を組み立てる。"""
+    parts: list[str] = []
+    parts.append("# PreCompact Dump")
+    parts.append("")
+    parts.append(f"- **session_id**: `{session_id or 'unknown'}`")
+    parts.append(f"- **trigger**: `{trigger or 'unknown'}`")
+    parts.append(f"- **saved_at**: `{datetime.datetime.now(datetime.UTC).isoformat()}`")
+    parts.append("")
+    parts.append("## Working Context")
+    parts.append("")
+    parts.append(_format_working_context(working_ctx))
+    parts.append("## Plans.md Snapshot")
+    parts.append("")
+    if plans_text:
+        parts.append("```markdown")
+        parts.append(plans_text.rstrip())
+        parts.append("```")
+    else:
+        parts.append("_(Plans.md not found)_")
+    parts.append("")
+    return "\n".join(parts)
+
+
+def _prune_old_dumps(shared_dir: str, keep: int = MAX_DUMP_FILES) -> None:
+    """古いダンプファイルを削除する（最新 keep 件だけ残す）。"""
+    try:
+        entries = [
+            os.path.join(shared_dir, name)
+            for name in os.listdir(shared_dir)
+            if name.startswith("precompact-") and name.endswith(".md")
+        ]
+    except OSError:
+        return
+    entries.sort()
+    for path in entries[:-keep]:
+        try:
+            os.remove(path)
+        except OSError:
+            pass
+
+
+def write_dump(project_dir: str, text: str) -> str:
+    """ダンプファイルを書き出し、絶対パスを返す。"""
+    shared_dir = get_shared_dir(project_dir)
+    Path(shared_dir).mkdir(parents=True, exist_ok=True)
+    filename = f"precompact-{_now_stamp()}.md"
+    dump_path = os.path.join(shared_dir, filename)
+    with open(dump_path, "w", encoding="utf-8") as f:
+        f.write(text)
+    _prune_old_dumps(shared_dir)
+    return dump_path
+
+
+@safe_hook_execution
+def main() -> None:
+    """PreCompact hook のエントリポイント。"""
+    data = read_hook_input()
+
+    project_dir = get_project_dir(data)
+    session_id = str(data.get("session_id") or "")
+    trigger = str(data.get("trigger") or "")
+
+    working_ctx = read_working_context(project_dir)
+    plans_text = _read_plans(project_dir)
+
+    text = build_dump_text(
+        session_id=session_id,
+        trigger=trigger,
+        working_ctx=working_ctx,
+        plans_text=plans_text,
+    )
+    dump_path = write_dump(project_dir, text)
+
+    # 監査ログにも小さく痕跡を残す（audit 未導入時はスキップ）
+    if _emit_event is not None and session_id:
+        try:
+            _emit_event(
+                "precompact",
+                {
+                    "trigger": trigger,
+                    "dump_path": os.path.relpath(dump_path, project_dir),
+                    "bytes": len(text),
+                    "has_plans": bool(plans_text),
+                },
+                session_id=session_id,
+                project_dir=project_dir,
+            )
+        except Exception:  # pragma: no cover
+            pass
+
+    print(f"precompact-dump: saved to {dump_path}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/core/hooks/precompact-dump.py
+++ b/packages/core/hooks/precompact-dump.py
@@ -161,12 +161,30 @@ def write_dump(project_dir: str, text: str) -> str:
     return dump_path
 
 
+def _resolve_project_dir(data: dict) -> str:
+    """hook 入力からプロジェクトディレクトリを取得し、検証する。
+
+    この hook は `.claude/context/shared/` 配下にファイルを書き込むため、
+    異常値（相対パス・存在しないパス・空文字）を受け取ると想定外の場所に
+    書き込みが発生しうる。正規化 + 存在確認を行い、不正時は CWD へ fallback する。
+    """
+    raw = get_project_dir(data)
+    resolved = os.path.abspath(raw) if raw else ""
+    if not resolved or not os.path.isdir(resolved):
+        print(
+            f"precompact-dump: invalid cwd from hook input: {raw!r}; fallback to current directory",
+            file=sys.stderr,
+        )
+        return os.getcwd()
+    return resolved
+
+
 @safe_hook_execution
 def main() -> None:
     """PreCompact hook のエントリポイント。"""
     data = read_hook_input()
 
-    project_dir = get_project_dir(data)
+    project_dir = _resolve_project_dir(data)
     session_id = str(data.get("session_id") or "")
     trigger = str(data.get("trigger") or "")
 

--- a/packages/core/hooks/precompact-dump.py
+++ b/packages/core/hooks/precompact-dump.py
@@ -47,8 +47,14 @@ MAX_DUMP_FILES = 20
 
 
 def _now_stamp() -> str:
-    """ファイル名用のタイムスタンプを返す（UTC, コロン無し）。"""
-    return datetime.datetime.now(datetime.UTC).strftime("%Y%m%dT%H%M%SZ")
+    """ファイル名用のタイムスタンプを返す(UTC, コロン無し)。
+
+    秒精度だけだと同一秒内の複数 PreCompact 実行でファイル名が衝突し、
+    古い dump を上書きしてしまうため、マイクロ秒まで含めて一意化する。
+    形式: `YYYYMMDDTHHMMSS-ffffffZ`（辞書順 = 時系列順）。
+    """
+    now = datetime.datetime.now(datetime.UTC)
+    return now.strftime("%Y%m%dT%H%M%S") + f"-{now.microsecond:06d}Z"
 
 
 def _read_plans(project_dir: str) -> str:
@@ -189,8 +195,11 @@ def main() -> None:
                 session_id=session_id,
                 project_dir=project_dir,
             )
-        except Exception:  # pragma: no cover
-            pass
+        except Exception as exc:  # pragma: no cover - 診断ログのみ、フックは止めない
+            print(
+                f"precompact-dump: failed to emit audit event: {exc}",
+                file=sys.stderr,
+            )
 
     print(f"precompact-dump: saved to {dump_path}", file=sys.stderr)
 

--- a/packages/core/manifest.json
+++ b/packages/core/manifest.json
@@ -16,7 +16,8 @@
       { "file": "capture-task-result.py", "matcher": "Agent|Task" },
       { "file": "update-working-context.py", "matcher": "Edit" },
       { "file": "update-working-context.py", "matcher": "Write" }
-    ]
+    ],
+    "PreCompact": ["precompact-dump.py"]
   },
   "files": [
     "hooks/hook_common.py",
@@ -29,7 +30,8 @@
     "hooks/capture-task-result.py",
     "hooks/inject-shared-context.py",
     "hooks/update-working-context.py",
-    "hooks/cleanup-session-context.py"
+    "hooks/cleanup-session-context.py",
+    "hooks/precompact-dump.py"
   ],
   "skills": ["preflight", "startproject", "checkpointing", "task-state", "design"],
   "agents": [],

--- a/packages/core/tests/test_precompact_dump.py
+++ b/packages/core/tests/test_precompact_dump.py
@@ -94,18 +94,26 @@ class TestWriteDump:
         assert Path(path).name.endswith(".md")
         assert Path(path).read_text(encoding="utf-8") == "# hello\n"
 
-    def test_prunes_old_dumps(self, tmp_path: Path) -> None:
-        """古いダンプは MAX_DUMP_FILES を超えると削除され、新規 dump は残ることを確認する。"""
+    def test_prunes_old_dumps(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """古いダンプは MAX_DUMP_FILES を超えると削除され、新規 dump は残ることを確認する。
+
+        実行時刻に依存しないよう `_now_stamp` を固定値にモンキーパッチする。
+        古いダンプよりも必ず後ろに並ぶタイムスタンプを使うことで、ソート順が
+        実時刻に関係なく決定的になる。
+        """
         project_dir = str(tmp_path)
         shared_dir = tmp_path / ".claude" / "context" / "shared"
         shared_dir.mkdir(parents=True)
 
-        # 既存ダンプを 21 個作る（閾値 +1）。
-        # ファイル名を本番と同じ `YYYYMMDDTHHMMSSZ` 形式にして、辞書順 = 時系列順になるよう揃える。
-        # ゼロ埋めされた `000000` より後ろに並ぶ時刻を使い、新規 dump が必ず末尾に来るようにする。
-        old_names = [f"precompact-20260101T00{i:04d}Z.md" for i in range(21)]
+        # 既存ダンプを 21 個作る（MAX_DUMP_FILES + 1）。
+        # `_now_stamp` が返すフォーマットに合わせてゼロ埋めし、辞書順 = 時系列順にする。
+        old_names = [f"precompact-20260101T000000-{i:06d}Z.md" for i in range(21)]
         for name in old_names:
             (shared_dir / name).write_text("x")
+
+        # 新規 dump は必ず old_names の最後より後ろに並ぶタイムスタンプにする
+        fixed_stamp = "20991231T235959-999999Z"
+        monkeypatch.setattr(precompact, "_now_stamp", lambda: fixed_stamp)
 
         new_path = precompact.write_dump(project_dir, "new")
 
@@ -114,7 +122,8 @@ class TestWriteDump:
         )
         # 件数が MAX_DUMP_FILES 以内に収まっている
         assert len(remaining_names) == precompact.MAX_DUMP_FILES
-        # 新規 dump は必ず残る
+        # 新規 dump は必ず残る（固定スタンプが最後尾なので確実に保持される）
+        assert Path(new_path).name == f"precompact-{fixed_stamp}.md"
         assert Path(new_path).exists()
         assert Path(new_path).name in remaining_names
         # 最古のダンプ（先頭）は削除されている

--- a/packages/core/tests/test_precompact_dump.py
+++ b/packages/core/tests/test_precompact_dump.py
@@ -1,0 +1,163 @@
+"""precompact-dump.py のユニットテスト。"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+from tests.module_loader import REPO_ROOT, load_module
+
+# worktree の stale コピーを参照しないよう、テスト中は REPO_ROOT を強制する。
+os.environ["AI_ORCHESTRA_DIR"] = str(REPO_ROOT)
+
+HOOKS_DIR = REPO_ROOT / "packages" / "core" / "hooks"
+if str(HOOKS_DIR) not in sys.path:
+    sys.path.insert(0, str(HOOKS_DIR))
+
+precompact = load_module("precompact_dump", "packages/core/hooks/precompact-dump.py")
+
+
+class TestFormatWorkingContext:
+    """`_format_working_context` のテスト。"""
+
+    def test_empty_returns_placeholder(self) -> None:
+        """空辞書の場合は empty プレースホルダが返ることを確認する。"""
+        result = precompact._format_working_context({})
+        assert "empty" in result
+
+    def test_formats_known_fields(self) -> None:
+        """既知のキーが適切に整形されることを確認する。"""
+        ctx = {
+            "current_phase": "implementation",
+            "updated_at": "2026-04-11T03:00:00+00:00",
+            "modified_files": ["a.py", "b.ts"],
+            "decisions": ["use PostgreSQL"],
+        }
+        text = precompact._format_working_context(ctx)
+        assert "implementation" in text
+        assert "a.py" in text
+        assert "b.ts" in text
+        assert "use PostgreSQL" in text
+
+    def test_includes_extra_keys(self) -> None:
+        """既知以外のキーも other セクションに含まれることを確認する。"""
+        ctx = {"current_phase": "x", "custom_field": "hello"}
+        text = precompact._format_working_context(ctx)
+        assert "custom_field" in text
+
+
+class TestBuildDumpText:
+    """`build_dump_text` のテスト。"""
+
+    def test_includes_metadata_and_plans(self) -> None:
+        """session_id / trigger / plans が全て含まれることを確認する。"""
+        text = precompact.build_dump_text(
+            session_id="s1",
+            trigger="auto",
+            working_ctx={"current_phase": "design"},
+            plans_text="# Plans\n- cc:WIP task",
+        )
+        assert "session_id" in text
+        assert "s1" in text
+        assert "auto" in text
+        assert "design" in text
+        assert "cc:WIP task" in text
+        assert "```markdown" in text
+
+    def test_missing_plans_uses_placeholder(self) -> None:
+        """Plans.md が無い場合はプレースホルダが入ることを確認する。"""
+        text = precompact.build_dump_text(
+            session_id="s1",
+            trigger="manual",
+            working_ctx={},
+            plans_text="",
+        )
+        assert "Plans.md not found" in text
+
+
+class TestWriteDump:
+    """`write_dump` のテスト。"""
+
+    def test_creates_file_in_shared_dir(self, tmp_path: Path) -> None:
+        """ダンプが .claude/context/shared/ 配下に作られることを確認する。"""
+        project_dir = str(tmp_path)
+        path = precompact.write_dump(project_dir, "# hello\n")
+
+        shared_dir = tmp_path / ".claude" / "context" / "shared"
+        assert Path(path).parent == shared_dir
+        assert Path(path).name.startswith("precompact-")
+        assert Path(path).name.endswith(".md")
+        assert Path(path).read_text(encoding="utf-8") == "# hello\n"
+
+    def test_prunes_old_dumps(self, tmp_path: Path) -> None:
+        """古いダンプは MAX_DUMP_FILES を超えると削除され、新規 dump は残ることを確認する。"""
+        project_dir = str(tmp_path)
+        shared_dir = tmp_path / ".claude" / "context" / "shared"
+        shared_dir.mkdir(parents=True)
+
+        # 既存ダンプを 21 個作る（閾値 +1）。
+        # ファイル名を本番と同じ `YYYYMMDDTHHMMSSZ` 形式にして、辞書順 = 時系列順になるよう揃える。
+        # ゼロ埋めされた `000000` より後ろに並ぶ時刻を使い、新規 dump が必ず末尾に来るようにする。
+        old_names = [f"precompact-20260101T00{i:04d}Z.md" for i in range(21)]
+        for name in old_names:
+            (shared_dir / name).write_text("x")
+
+        new_path = precompact.write_dump(project_dir, "new")
+
+        remaining_names = sorted(
+            p.name for p in shared_dir.iterdir() if p.name.startswith("precompact-")
+        )
+        # 件数が MAX_DUMP_FILES 以内に収まっている
+        assert len(remaining_names) == precompact.MAX_DUMP_FILES
+        # 新規 dump は必ず残る
+        assert Path(new_path).exists()
+        assert Path(new_path).name in remaining_names
+        # 最古のダンプ（先頭）は削除されている
+        assert old_names[0] not in remaining_names
+
+
+class TestMain:
+    """`main` のエンドツーエンド動作を確認する。"""
+
+    def _invoke(self, payload: dict, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(payload)))
+        precompact.main()
+
+    def test_writes_dump_with_plans(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Plans.md ありの入力で dump ファイルが生成されることを確認する。"""
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        (claude_dir / "Plans.md").write_text("# Plans\n- `cc:WIP` build feature\n")
+
+        # audit への副作用を遮断（テストは Markdown ダンプだけを検証する）
+        emit_calls: list[tuple] = []
+
+        def _fake_emit(*args, **kwargs) -> None:
+            emit_calls.append((args, kwargs))
+
+        monkeypatch.setattr(precompact, "_emit_event", _fake_emit)
+
+        payload = {
+            "session_id": "sess-x",
+            "cwd": str(tmp_path),
+            "trigger": "manual",
+        }
+        self._invoke(payload, monkeypatch)
+
+        # _emit_event は 1 回だけ呼ばれ、event_type と session_id が正しいこと
+        assert len(emit_calls) == 1
+        args, kwargs = emit_calls[0]
+        assert args[0] == "precompact"
+        assert kwargs.get("session_id") == "sess-x"
+
+        dumps = list((tmp_path / ".claude" / "context" / "shared").iterdir())
+        assert len(dumps) == 1
+        assert dumps[0].name.startswith("precompact-")
+        content = dumps[0].read_text(encoding="utf-8")
+        assert "sess-x" in content
+        assert "build feature" in content

--- a/packages/core/tests/test_precompact_dump.py
+++ b/packages/core/tests/test_precompact_dump.py
@@ -130,6 +130,46 @@ class TestWriteDump:
         assert old_names[0] not in remaining_names
 
 
+class TestResolveProjectDir:
+    """`_resolve_project_dir` の hook 入力検証テスト。"""
+
+    def test_returns_absolute_path_for_valid_dir(self, tmp_path: Path) -> None:
+        """正常な cwd が渡されたとき絶対パスが返ることを確認する。"""
+        result = precompact._resolve_project_dir({"cwd": str(tmp_path)})
+        assert result == os.path.abspath(str(tmp_path))
+
+    def test_falls_back_for_nonexistent_path(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """存在しないパスが渡されたとき CWD にフォールバックし、stderr にログを出すことを確認する。"""
+        bogus = tmp_path / "does-not-exist"
+        result = precompact._resolve_project_dir({"cwd": str(bogus)})
+
+        assert result == os.getcwd()
+        err = capsys.readouterr().err
+        assert "invalid cwd" in err
+        assert "fallback" in err
+
+    def test_falls_back_for_empty_cwd(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """空文字 cwd かつ CLAUDE_PROJECT_DIR が無効な場合、CWD にフォールバックすることを確認する。"""
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path / "nonexistent"))
+        result = precompact._resolve_project_dir({"cwd": ""})
+        assert result == os.getcwd()
+
+    def test_normalizes_relative_path(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """相対パスが絶対パスに正規化されることを確認する。"""
+        monkeypatch.chdir(tmp_path)
+        sub = tmp_path / "sub"
+        sub.mkdir()
+        result = precompact._resolve_project_dir({"cwd": "sub"})
+        assert result == os.path.abspath(str(sub))
+        assert os.path.isabs(result)
+
+
 class TestMain:
     """`main` のエンドツーエンド動作を確認する。"""
 

--- a/packages/quality-gates/hooks/turn-end-summary.py
+++ b/packages/quality-gates/hooks/turn-end-summary.py
@@ -147,7 +147,8 @@ def _count_plans(project_dir: str) -> dict[str, int]:
         return {}
     try:
         tasks = parse_tasks(content)
-    except Exception:
+    except Exception as exc:  # pragma: no cover - 診断ログのみ
+        print(f"turn-end-summary: failed to parse Plans.md: {exc}", file=sys.stderr)
         return {}
     return {state: len(items) for state, items in tasks.items()}
 
@@ -219,8 +220,8 @@ def _emit_turn_end(
             session_id=session_id,
             project_dir=project_dir,
         )
-    except Exception:  # pragma: no cover
-        pass
+    except Exception as exc:  # pragma: no cover - 診断ログのみ、フックは止めない
+        print(f"turn-end-summary: audit emit skipped: {exc}", file=sys.stderr)
 
 
 @safe_hook_execution

--- a/packages/quality-gates/hooks/turn-end-summary.py
+++ b/packages/quality-gates/hooks/turn-end-summary.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+"""Stop hook: ターン終了時にサマリーと軽量リマインダーを出力する。
+
+責務（A + B + E1 合成）:
+- A: audit v1 ログに `turn_end` イベントを追記（ファイル編集数、Plans 件数等の集計）
+- B: working-context の modified_files から lint/test 未実行の可能性があるファイルを抽出
+- E1: Plans.md の WIP / TODO / blocked 件数表示（SSOT への気付きを促す）
+
+制約:
+- `decision: block` は一切使わない（UX 安全）
+- `stop_hook_active=true` の時は一切処理しない（再入ループ防止）
+- transcript_path は読まない（コスト削減）
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from collections.abc import Callable
+from pathlib import Path
+
+_hook_dir = os.path.dirname(os.path.abspath(__file__))
+if _hook_dir not in sys.path:
+    sys.path.insert(0, _hook_dir)
+
+_orchestra_dir = os.environ.get("AI_ORCHESTRA_DIR", "")
+if _orchestra_dir:
+    _core_hooks = os.path.join(_orchestra_dir, "packages", "core", "hooks")
+    if os.path.isdir(_core_hooks) and _core_hooks not in sys.path:
+        sys.path.insert(0, _core_hooks)
+    _audit_hooks = os.path.join(_orchestra_dir, "packages", "audit", "hooks")
+    if os.path.isdir(_audit_hooks) and _audit_hooks not in sys.path:
+        sys.path.insert(0, _audit_hooks)
+
+try:
+    from hook_common import read_hook_input, safe_hook_execution
+except ImportError:  # pragma: no cover - core 未導入時のフォールバック
+    import functools
+
+    def read_hook_input() -> dict:  # type: ignore[misc]
+        try:
+            return json.loads(sys.stdin.read())
+        except (json.JSONDecodeError, ValueError):
+            return {}
+
+    def safe_hook_execution(func: Callable[[], None]) -> Callable[[], None]:  # type: ignore[misc]
+        @functools.wraps(func)
+        def wrapper() -> None:
+            try:
+                func()
+            except Exception as e:
+                print(f"Hook error ({func.__module__}): {e}", file=sys.stderr)
+                sys.exit(0)
+
+        return wrapper
+
+
+try:
+    from context_store import get_project_dir, read_working_context
+except ImportError:  # pragma: no cover
+
+    def get_project_dir(data: dict) -> str:  # type: ignore[misc]
+        return data.get("cwd") or os.environ.get("CLAUDE_PROJECT_DIR") or os.getcwd()
+
+    def read_working_context(_project_dir: str) -> dict:  # type: ignore[misc]
+        return {}
+
+
+try:
+    from event_logger import emit_event as _emit_event  # type: ignore[import-not-found]
+except ImportError:  # pragma: no cover - audit 未導入時のフォールバック
+    _emit_event = None  # type: ignore[assignment]
+
+
+def _load_parse_tasks() -> Callable[[str], dict] | None:
+    """`load-task-state.py` から `parse_tasks` を動的に取得する。
+
+    通常の `from load_task_state import parse_tasks` はファイル名にハイフンが
+    含まれるため成立しない。importlib で直接ロードし、`sys.modules` にも
+    登録しておくことで内部の自己参照 import にも対応する。
+    失敗時は `None` を返し、stderr に診断ログを残す。
+    """
+    import importlib.util
+
+    if not _orchestra_dir:
+        return None
+    plans_path = os.path.join(_orchestra_dir, "packages", "core", "hooks", "load-task-state.py")
+    if not os.path.isfile(plans_path):
+        return None
+
+    module_name = "orchestra_load_task_state"
+    spec = importlib.util.spec_from_file_location(module_name, plans_path)
+    if spec is None or spec.loader is None:
+        print("turn-end-summary: cannot create spec for load-task-state.py", file=sys.stderr)
+        return None
+
+    module = importlib.util.module_from_spec(spec)
+    # 実行前に sys.modules へ登録（モジュール内部の自己参照 import に備える）
+    sys.modules[module_name] = module
+    try:
+        spec.loader.exec_module(module)
+    except Exception as e:  # pragma: no cover - 診断ログのみ
+        print(f"turn-end-summary: failed to load parse_tasks: {e}", file=sys.stderr)
+        sys.modules.pop(module_name, None)
+        return None
+
+    return getattr(module, "parse_tasks", None)
+
+
+parse_tasks = _load_parse_tasks()
+
+
+# 拡張子 → lint/test 対象判定に使うコード拡張子
+_CODE_EXTENSIONS = {
+    ".py",
+    ".js",
+    ".ts",
+    ".tsx",
+    ".jsx",
+    ".go",
+    ".rs",
+    ".java",
+    ".rb",
+    ".sh",
+    ".bash",
+    ".zsh",
+}
+
+
+def _read_plans(project_dir: str) -> str:
+    """Plans.md の内容を読み込む。存在しない場合は空文字を返す。"""
+    plans_path = os.path.join(project_dir, ".claude", "Plans.md")
+    try:
+        with open(plans_path, encoding="utf-8") as f:
+            return f.read()
+    except OSError:
+        return ""
+
+
+def _count_plans(project_dir: str) -> dict[str, int]:
+    """Plans.md を parse してタスク件数を返す。"""
+    if parse_tasks is None:
+        return {}
+    content = _read_plans(project_dir)
+    if not content:
+        return {}
+    try:
+        tasks = parse_tasks(content)
+    except Exception:
+        return {}
+    return {state: len(items) for state, items in tasks.items()}
+
+
+def _extract_code_files(working_ctx: dict) -> list[str]:
+    """working-context から lint 対象となりえるコードファイルを抽出する。"""
+    modified = working_ctx.get("modified_files")
+    if not isinstance(modified, list):
+        return []
+    result: list[str] = []
+    for item in modified:
+        if not isinstance(item, str):
+            continue
+        ext = Path(item).suffix.lower()
+        if ext in _CODE_EXTENSIONS:
+            result.append(item)
+    return result
+
+
+def build_summary_text(
+    *,
+    code_files: list[str],
+    plans_counts: dict[str, int],
+    total_modified: int,
+) -> str:
+    """turn-end サマリーの Markdown を組み立てる。空なら空文字を返す。"""
+    lines: list[str] = []
+
+    if total_modified > 0 or code_files:
+        lines.append(f"- Modified: {total_modified} files (code: {len(code_files)})")
+
+    if plans_counts:
+        parts = []
+        for state in ("WIP", "TODO", "blocked"):
+            count = plans_counts.get(state, 0)
+            if count:
+                parts.append(f"{state} {count}")
+        if parts:
+            lines.append(f"- Plans.md: {', '.join(parts)}")
+
+    if code_files:
+        preview = ", ".join(code_files[-5:])
+        lines.append(f"- Reminder: 編集済みコードファイルの lint/test 未実行の可能性 ({preview})")
+
+    if not lines:
+        return ""
+    return "[Turn Summary]\n" + "\n".join(lines)
+
+
+def _emit_turn_end(
+    *,
+    session_id: str,
+    project_dir: str,
+    code_files: list[str],
+    plans_counts: dict[str, int],
+    total_modified: int,
+) -> None:
+    """audit v1 ログに turn_end イベントを追記する。audit 未導入なら何もしない。"""
+    if _emit_event is None or not session_id:
+        return
+    try:
+        _emit_event(
+            "turn_end",
+            {
+                "modified_files": total_modified,
+                "code_files": len(code_files),
+                "plans_counts": plans_counts,
+            },
+            session_id=session_id,
+            project_dir=project_dir,
+        )
+    except Exception:  # pragma: no cover
+        pass
+
+
+@safe_hook_execution
+def main() -> None:
+    """Stop hook のエントリポイント。"""
+    data = read_hook_input()
+
+    # 再入ループ防止（Stop hook が block した後の再発火をスキップする安全弁）
+    if data.get("stop_hook_active") is True:
+        return
+
+    project_dir = get_project_dir(data)
+    session_id = str(data.get("session_id") or "")
+
+    working_ctx = read_working_context(project_dir)
+    modified = working_ctx.get("modified_files") or []
+    total_modified = len(modified) if isinstance(modified, list) else 0
+
+    code_files = _extract_code_files(working_ctx)
+    plans_counts = _count_plans(project_dir)
+
+    _emit_turn_end(
+        session_id=session_id,
+        project_dir=project_dir,
+        code_files=code_files,
+        plans_counts=plans_counts,
+        total_modified=total_modified,
+    )
+
+    summary = build_summary_text(
+        code_files=code_files,
+        plans_counts=plans_counts,
+        total_modified=total_modified,
+    )
+    if not summary:
+        return
+
+    output = {
+        "hookSpecificOutput": {
+            "hookEventName": "Stop",
+            "additionalContext": summary,
+        }
+    }
+    print(json.dumps(output, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/quality-gates/manifest.json
+++ b/packages/quality-gates/manifest.json
@@ -9,13 +9,15 @@
       {"file": "post-test-analysis.py", "matcher": "Bash"},
       {"file": "lint-on-save.py", "matcher": "Edit|Write"},
       {"file": "test-gate-checker.py", "matcher": "Edit|Write"}
-    ]
+    ],
+    "Stop": ["turn-end-summary.py"]
   },
   "files": [
     "hooks/post-implementation-review.py",
     "hooks/post-test-analysis.py",
     "hooks/lint-on-save.py",
-    "hooks/test-gate-checker.py"
+    "hooks/test-gate-checker.py",
+    "hooks/turn-end-summary.py"
   ],
   "skills": ["review", "tdd", "design-tracker", "release-readiness"],
   "agents": [],

--- a/packages/quality-gates/tests/test_turn_end_summary.py
+++ b/packages/quality-gates/tests/test_turn_end_summary.py
@@ -1,0 +1,157 @@
+"""turn-end-summary.py のユニットテスト。"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+from tests.module_loader import REPO_ROOT, load_module
+
+# worktree の stale コピーを参照しないよう、テスト中は REPO_ROOT を強制する。
+os.environ["AI_ORCHESTRA_DIR"] = str(REPO_ROOT)
+
+_qg_hooks = str(REPO_ROOT / "packages" / "quality-gates" / "hooks")
+_core_hooks = str(REPO_ROOT / "packages" / "core" / "hooks")
+_audit_hooks = str(REPO_ROOT / "packages" / "audit" / "hooks")
+for p in [_qg_hooks, _core_hooks, _audit_hooks]:
+    if p not in sys.path:
+        sys.path.insert(0, p)
+
+turn_end = load_module(
+    "turn_end_summary",
+    "packages/quality-gates/hooks/turn-end-summary.py",
+)
+
+
+class TestExtractCodeFiles:
+    """`_extract_code_files` のテスト。"""
+
+    def test_filters_to_code_extensions(self) -> None:
+        """コード拡張子のみ残ることを確認する。"""
+        ctx = {
+            "modified_files": [
+                "a.py",
+                "README.md",
+                "b.ts",
+                "data.json",
+                "c.go",
+                "notes.txt",
+            ]
+        }
+        files = turn_end._extract_code_files(ctx)
+        assert set(files) == {"a.py", "b.ts", "c.go"}
+
+    def test_handles_missing_list(self) -> None:
+        """modified_files が無い場合は空リストを返す。"""
+        assert turn_end._extract_code_files({}) == []
+
+
+class TestBuildSummaryText:
+    """`build_summary_text` のテスト。"""
+
+    def test_empty_returns_empty_string(self) -> None:
+        """何も変更なし & Plans 空なら空文字を返すことを確認する。"""
+        assert turn_end.build_summary_text(code_files=[], plans_counts={}, total_modified=0) == ""
+
+    def test_includes_modified_and_plans(self) -> None:
+        """変更数と Plans 件数の両方が含まれることを確認する。"""
+        text = turn_end.build_summary_text(
+            code_files=["a.py"],
+            plans_counts={"WIP": 2, "TODO": 3, "blocked": 0, "done": 5},
+            total_modified=4,
+        )
+        assert "Turn Summary" in text
+        assert "4 files" in text
+        assert "WIP 2" in text
+        assert "TODO 3" in text
+        # done は表示しない（運用ノイズ削減）
+        assert "done 5" not in text
+
+    def test_reminder_only_when_code_files(self) -> None:
+        """code_files があるときだけ Reminder 行が出ることを確認する。"""
+        text_without = turn_end.build_summary_text(
+            code_files=[], plans_counts={"WIP": 1}, total_modified=2
+        )
+        assert "Reminder" not in text_without
+
+        text_with = turn_end.build_summary_text(
+            code_files=["foo.py"], plans_counts={}, total_modified=1
+        )
+        assert "Reminder" in text_with
+        assert "foo.py" in text_with
+
+
+class TestMain:
+    """`main` の入出力動作を確認する。"""
+
+    def _invoke(
+        self, payload: dict, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> str:
+        monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(payload)))
+        turn_end.main()
+        return capsys.readouterr().out
+
+    def test_stop_hook_active_skips(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+        tmp_path: Path,
+    ) -> None:
+        """stop_hook_active=true のときは出力しないことを確認する（再入防止）。"""
+        (tmp_path / ".claude").mkdir()
+        payload = {
+            "session_id": "s1",
+            "cwd": str(tmp_path),
+            "stop_hook_active": True,
+        }
+        output = self._invoke(payload, monkeypatch, capsys)
+        assert output == ""
+
+    def test_no_changes_no_output(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+        tmp_path: Path,
+    ) -> None:
+        """Plans.md も working-context も空なら何も出力しないことを確認する。"""
+        (tmp_path / ".claude").mkdir()
+        payload = {"session_id": "s1", "cwd": str(tmp_path)}
+        output = self._invoke(payload, monkeypatch, capsys)
+        assert output == ""
+
+    def test_outputs_additional_context(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+        tmp_path: Path,
+    ) -> None:
+        """Plans.md と working-context から additionalContext を組み立てることを確認する。"""
+        claude_dir = tmp_path / ".claude"
+        (claude_dir / "context" / "shared").mkdir(parents=True)
+        (claude_dir / "context" / "shared" / "working-context.json").write_text(
+            json.dumps(
+                {
+                    "modified_files": ["main.py", "docs.md", "server.ts"],
+                    "updated_at": "2026-04-11T03:00:00+00:00",
+                }
+            )
+        )
+        (claude_dir / "Plans.md").write_text("# Plans\n- `cc:WIP` A task\n- `cc:TODO` B task\n")
+
+        payload = {"session_id": "s1", "cwd": str(tmp_path)}
+        output = self._invoke(payload, monkeypatch, capsys)
+        assert output
+        parsed = json.loads(output)
+        text = parsed["hookSpecificOutput"]["additionalContext"]
+        assert "Modified: 3 files" in text
+        # main.py と server.ts はコード
+        assert "code: 2" in text
+        assert "WIP 1" in text
+        assert "TODO 1" in text
+        # Stop hook は decision を一切返さない
+        assert "decision" not in parsed

--- a/tests/e2e/test_e2e_sync.py
+++ b/tests/e2e/test_e2e_sync.py
@@ -212,9 +212,9 @@ class TestHookSync:
             (e2e_project / ".claude" / "settings.local.json").read_text(encoding="utf-8")
         )
         hooks_after = json.dumps(settings_after.get("hooks", {})).count("command")
-        # audit manifest に宣言された 7 hooks が追加される
+        # audit manifest に宣言された 8 hooks が追加される
         # count("command") は "type": "command" と "command": "..." の 2 箇所を拾うため x2
-        assert hooks_after - hooks_before == 7 * 2
+        assert hooks_after - hooks_before == 8 * 2
 
     def test_hook_removed_on_uninstall(self, e2e_project: Path) -> None:
         """#33: パッケージ uninstall で hooks が除去"""
@@ -230,8 +230,8 @@ class TestHookSync:
             (e2e_project / ".claude" / "settings.local.json").read_text(encoding="utf-8")
         )
         hooks_without = json.dumps(settings_without.get("hooks", {})).count("command")
-        # audit package の 7 hooks が全て除去される
-        assert hooks_with - hooks_without == 7 * 2
+        # audit package の 8 hooks が全て除去される
+        assert hooks_with - hooks_without == 8 * 2
 
     def test_manual_hook_preserved(self, e2e_project: Path) -> None:
         """#34: 手動追加した hook は sync で削除されない"""


### PR DESCRIPTION
## Summary

Claude Code の最新 hook API に合わせて 3 つの新しいフックを追加しました。

- **PreCompact** (`packages/core/hooks/precompact-dump.py`)
  圧縮直前に `working-context.json` と `Plans.md` を `.claude/context/shared/precompact-{ts}.md` へ退避し、最新 20 件までローテート。`context_store` に公開 API `get_shared_dir()` を追加。
- **InstructionsLoaded** (`packages/audit/hooks/audit-instructions-loaded.py`)
  `CLAUDE.md` / ルール等のロードを audit v1 ログに記録し、`load_reason` / `file_path` / `globs` を追跡可能にする。`audit-flags.json` の `features.instructions_loaded.enabled` で無効化可。
- **Stop** (`packages/quality-gates/hooks/turn-end-summary.py`)
  ターン終了時に編集ファイル数 / Plans.md の WIP・TODO・blocked 件数 / lint 未実行リマインダーを `additionalContext` で注入。`decision: block` は一切使わず、`stop_hook_active` で再入ループを防止。

周辺整備:

- `audit` 統一スキーマに `instructions_loaded` / `turn_end` / `precompact` イベント型を追加
- 各 `manifest.json` に新 hook を宣言し `sync-orchestra` 経由で自動配布
- 3 hook に対応するユニットテスト 24 本を追加
- e2e の audit hook 数アサートを `7 → 8` に更新

## Design Notes

- **PreCompact の退避先**: `.claude/context/shared/` — `cleanup-session-context.py` が `session/` のみ削除するのでセッション間で退避ファイルが残ります
- **Stop の `audit` 連携**: `quality-gates → audit` の hard depends を増やさず `try/except ImportError` でソフト依存
- **Stop の安全性**: `decision: block` 不使用 + `stop_hook_active` 再入防止 + `transcript_path` 非読み込み（コスト削減）

## Review

`/review code` を実施し、Critical 1 件 + High 3 件 + Medium 3 件を検出・全修正済み:

- **Critical**: `_prune_old_dumps` テストの辞書順ソート前提が壊れており新規 dump が削除されるケースを見逃していた → タイムスタンプ形式に揃え、新規 dump 存在 assert を追加
- **High**: (1) `context_store._shared_dir` private 参照 → `get_shared_dir()` 公開 API 化、(2) `turn-end-summary.py` に `@safe_hook_execution` 適用 + `hook_common.read_hook_input` 利用で重複排除、(3) `parse_tasks` 動的ロードに `sys.modules` 登録 + 診断ログ追加
- **Medium**: (1) `sys.path` 追加に `os.path.isdir()` ガード、(2) High (2) で自然解消、(3) `_emit_event` をテストでモック

## Test plan

- [x] `pytest -q` → 1151 passed, 17 skipped, 0 failed
- [x] `ruff check .` → All checks passed
- [x] `ruff format --check .` → 130 files already formatted
- [x] 新 hook 3 本に 24 本のユニットテスト追加（正常系 / 異常系 / 境界値）
- [ ] 実プロジェクトで SessionStart 時に `settings.local.json` へ 3 hook が自動展開されることを手動確認
- [ ] PreCompact 手動トリガー時に `.claude/context/shared/precompact-*.md` が生成されることを手動確認
- [ ] Stop 時に `additionalContext` が注入されることを手動確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 命令読み込み（instructions_loaded）の監査ログ出力を追加
  * コンテキスト前圧縮（precompact）ダンプを追加（.claude/context/shared に保存・古いダンプを削除）
  * ターン終了時のサマリーレポート出力を追加（JSON と追加のMarkdown要約）

* **変更**
  * 監査イベント許可リストに instructions_loaded / turn_end / precompact を追加

* **テスト**
  * 新機能の単体・統合テストを追加
  * E2Eテストの期待値を更新
<!-- end of auto-generated comment: release notes by coderabbit.ai -->