### PR TITLE
fix: Stop hook スキーマ違反と PR ラベル整合性の修正

### DIFF
--- a/.claude/orchestra.json
+++ b/.claude/orchestra.json
@@ -41,11 +41,11 @@
     "agents/testing-reality-checker.md",
     "agents/ux-reviewer.md",
     "config/agent-routing/cli-tools.yaml",
+    "config/audit/audit-flags.json",
+    "config/audit/delegation-policy.json",
     "config/cocoindex/cocoindex.yaml",
     "config/core/task-memory.yaml",
-    "config/git-workflow/sandbox-requirements.json",
-    "config/audit/delegation-policy.json",
-    "config/audit/audit-flags.json"
+    "config/git-workflow/sandbox-requirements.json"
   ],
-  "last_sync": "2026-04-09T11:36:54.729381+00:00"
+  "last_sync": "2026-04-11T07:26:22.086365+00:00"
 }

--- a/.claude/skills/issue-fix/SKILL.md
+++ b/.claude/skills/issue-fix/SKILL.md
@@ -78,18 +78,18 @@ PR 本文は以下のテンプレート構造に従う。プロジェクトに `
 ## Checklist
 
 - [ ] PR タイトルが GitHub Release にそのまま載っても読める
-- [ ] 適切なラベルを付けた (`feature` / `fix` / `docs` / `chore` / ...)
+- [ ] 適切なラベルを付けた (`bug` / `enhancement` / `documentation` / `refactor` / `task` / ...)
 - [ ] ユーザー向け変更がある場合は `CHANGELOG.md` の `Unreleased` を更新した
 ```
 
 ### セクション埋め込みルール
 
-| セクション | 入力ソース | 記述ルール |
-|-----------|-----------|-----------|
-| Summary | コミット履歴 + diff stat | 変更内容を箇条書きで要約 |
-| Testing | テスト実行結果 | 実施済みなら結果を記載、未実施なら理由を記載 |
-| Release Note | 変更内容の分析 | ユーザー向け変更がある場合のみ記載 |
-| Checklist | 自動チェック | 可能な項目は事前にチェック済みにする |
+| セクション   | 入力ソース               | 記述ルール                                   |
+| ------------ | ------------------------ | -------------------------------------------- |
+| Summary      | コミット履歴 + diff stat | 変更内容を箇条書きで要約                     |
+| Testing      | テスト実行結果           | 実施済みなら結果を記載、未実施なら理由を記載 |
+| Release Note | 変更内容の分析           | ユーザー向け変更がある場合のみ記載           |
+| Checklist    | 自動チェック             | 可能な項目は事前にチェック済みにする         |
 
 ## PR タイトル
 
@@ -99,17 +99,21 @@ PR 本文は以下のテンプレート構造に従う。プロジェクトに `
 
 ## ブランチプレフィックスとラベルの対応
 
-| ブランチプレフィックス | PR タイトルプレフィックス | ラベル |
-|---------------------|----------------------|--------|
-| `fix/` | `fix:` | `fix` |
-| `feat/` | `feat:` | `feature` |
-| `docs/` | `docs:` | `docs` |
-| `chore/` | `chore:` | `chore` |
-| `refactor/` | `refactor:` | `refactor` |
-| `test/` | `test:` | `test` |
-| `task/` | `chore:` | `chore` |
-| `release/` | `release:` | `release` |
-| その他 | `chore:` | `chore` |
+ラベルは GitHub リポジトリで実際に定義されているものに合わせる。存在しないラベルを指定すると `gh pr create` がエラーを返すため、ポリシーと実リポジトリを同期させる。
+
+| ブランチプレフィックス | PR タイトルプレフィックス | ラベル          |
+| ---------------------- | ------------------------- | --------------- |
+| `fix/`                 | `fix:`                    | `bug`           |
+| `feat/`                | `feat:`                   | `enhancement`   |
+| `docs/`                | `docs:`                   | `documentation` |
+| `chore/`               | `chore:`                  | `task`          |
+| `refactor/`            | `refactor:`               | `refactor`      |
+| `test/`                | `test:`                   | `task`          |
+| `task/`                | `chore:`                  | `task`          |
+| `release/`             | `release:`                | `task`          |
+| その他                 | `chore:`                  | `task`          |
+
+> **Note**: `bug` / `enhancement` / `documentation` は GitHub のデフォルトラベルをそのまま採用している。`refactor` / `task` はプロジェクト固有ラベル。リポジトリが異なるラベル体系を使っている場合は、この表と実ラベルを個別に調整すること。
 
 ## Issue 連携
 

--- a/.claude/skills/pr-create/SKILL.md
+++ b/.claude/skills/pr-create/SKILL.md
@@ -121,18 +121,18 @@ PR 本文は以下のテンプレート構造に従う。プロジェクトに `
 ## Checklist
 
 - [ ] PR タイトルが GitHub Release にそのまま載っても読める
-- [ ] 適切なラベルを付けた (`feature` / `fix` / `docs` / `chore` / ...)
+- [ ] 適切なラベルを付けた (`bug` / `enhancement` / `documentation` / `refactor` / `task` / ...)
 - [ ] ユーザー向け変更がある場合は `CHANGELOG.md` の `Unreleased` を更新した
 ```
 
 ### セクション埋め込みルール
 
-| セクション | 入力ソース | 記述ルール |
-|-----------|-----------|-----------|
-| Summary | コミット履歴 + diff stat | 変更内容を箇条書きで要約 |
-| Testing | テスト実行結果 | 実施済みなら結果を記載、未実施なら理由を記載 |
-| Release Note | 変更内容の分析 | ユーザー向け変更がある場合のみ記載 |
-| Checklist | 自動チェック | 可能な項目は事前にチェック済みにする |
+| セクション   | 入力ソース               | 記述ルール                                   |
+| ------------ | ------------------------ | -------------------------------------------- |
+| Summary      | コミット履歴 + diff stat | 変更内容を箇条書きで要約                     |
+| Testing      | テスト実行結果           | 実施済みなら結果を記載、未実施なら理由を記載 |
+| Release Note | 変更内容の分析           | ユーザー向け変更がある場合のみ記載           |
+| Checklist    | 自動チェック             | 可能な項目は事前にチェック済みにする         |
 
 ## PR タイトル
 
@@ -142,17 +142,21 @@ PR 本文は以下のテンプレート構造に従う。プロジェクトに `
 
 ## ブランチプレフィックスとラベルの対応
 
-| ブランチプレフィックス | PR タイトルプレフィックス | ラベル |
-|---------------------|----------------------|--------|
-| `fix/` | `fix:` | `fix` |
-| `feat/` | `feat:` | `feature` |
-| `docs/` | `docs:` | `docs` |
-| `chore/` | `chore:` | `chore` |
-| `refactor/` | `refactor:` | `refactor` |
-| `test/` | `test:` | `test` |
-| `task/` | `chore:` | `chore` |
-| `release/` | `release:` | `release` |
-| その他 | `chore:` | `chore` |
+ラベルは GitHub リポジトリで実際に定義されているものに合わせる。存在しないラベルを指定すると `gh pr create` がエラーを返すため、ポリシーと実リポジトリを同期させる。
+
+| ブランチプレフィックス | PR タイトルプレフィックス | ラベル          |
+| ---------------------- | ------------------------- | --------------- |
+| `fix/`                 | `fix:`                    | `bug`           |
+| `feat/`                | `feat:`                   | `enhancement`   |
+| `docs/`                | `docs:`                   | `documentation` |
+| `chore/`               | `chore:`                  | `task`          |
+| `refactor/`            | `refactor:`               | `refactor`      |
+| `test/`                | `test:`                   | `task`          |
+| `task/`                | `chore:`                  | `task`          |
+| `release/`             | `release:`                | `task`          |
+| その他                 | `chore:`                  | `task`          |
+
+> **Note**: `bug` / `enhancement` / `documentation` は GitHub のデフォルトラベルをそのまま採用している。`refactor` / `task` はプロジェクト固有ラベル。リポジトリが異なるラベル体系を使っている場合は、この表と実ラベルを個別に調整すること。
 
 ## Issue 連携
 

--- a/.codex/skills/issue-fix/SKILL.md
+++ b/.codex/skills/issue-fix/SKILL.md
@@ -78,18 +78,18 @@ PR 本文は以下のテンプレート構造に従う。プロジェクトに `
 ## Checklist
 
 - [ ] PR タイトルが GitHub Release にそのまま載っても読める
-- [ ] 適切なラベルを付けた (`feature` / `fix` / `docs` / `chore` / ...)
+- [ ] 適切なラベルを付けた (`bug` / `enhancement` / `documentation` / `refactor` / `task` / ...)
 - [ ] ユーザー向け変更がある場合は `CHANGELOG.md` の `Unreleased` を更新した
 ```
 
 ### セクション埋め込みルール
 
-| セクション | 入力ソース | 記述ルール |
-|-----------|-----------|-----------|
-| Summary | コミット履歴 + diff stat | 変更内容を箇条書きで要約 |
-| Testing | テスト実行結果 | 実施済みなら結果を記載、未実施なら理由を記載 |
-| Release Note | 変更内容の分析 | ユーザー向け変更がある場合のみ記載 |
-| Checklist | 自動チェック | 可能な項目は事前にチェック済みにする |
+| セクション   | 入力ソース               | 記述ルール                                   |
+| ------------ | ------------------------ | -------------------------------------------- |
+| Summary      | コミット履歴 + diff stat | 変更内容を箇条書きで要約                     |
+| Testing      | テスト実行結果           | 実施済みなら結果を記載、未実施なら理由を記載 |
+| Release Note | 変更内容の分析           | ユーザー向け変更がある場合のみ記載           |
+| Checklist    | 自動チェック             | 可能な項目は事前にチェック済みにする         |
 
 ## PR タイトル
 
@@ -99,17 +99,21 @@ PR 本文は以下のテンプレート構造に従う。プロジェクトに `
 
 ## ブランチプレフィックスとラベルの対応
 
-| ブランチプレフィックス | PR タイトルプレフィックス | ラベル |
-|---------------------|----------------------|--------|
-| `fix/` | `fix:` | `fix` |
-| `feat/` | `feat:` | `feature` |
-| `docs/` | `docs:` | `docs` |
-| `chore/` | `chore:` | `chore` |
-| `refactor/` | `refactor:` | `refactor` |
-| `test/` | `test:` | `test` |
-| `task/` | `chore:` | `chore` |
-| `release/` | `release:` | `release` |
-| その他 | `chore:` | `chore` |
+ラベルは GitHub リポジトリで実際に定義されているものに合わせる。存在しないラベルを指定すると `gh pr create` がエラーを返すため、ポリシーと実リポジトリを同期させる。
+
+| ブランチプレフィックス | PR タイトルプレフィックス | ラベル          |
+| ---------------------- | ------------------------- | --------------- |
+| `fix/`                 | `fix:`                    | `bug`           |
+| `feat/`                | `feat:`                   | `enhancement`   |
+| `docs/`                | `docs:`                   | `documentation` |
+| `chore/`               | `chore:`                  | `task`          |
+| `refactor/`            | `refactor:`               | `refactor`      |
+| `test/`                | `test:`                   | `task`          |
+| `task/`                | `chore:`                  | `task`          |
+| `release/`             | `release:`                | `task`          |
+| その他                 | `chore:`                  | `task`          |
+
+> **Note**: `bug` / `enhancement` / `documentation` は GitHub のデフォルトラベルをそのまま採用している。`refactor` / `task` はプロジェクト固有ラベル。リポジトリが異なるラベル体系を使っている場合は、この表と実ラベルを個別に調整すること。
 
 ## Issue 連携
 

--- a/.codex/skills/pr-create/SKILL.md
+++ b/.codex/skills/pr-create/SKILL.md
@@ -121,18 +121,18 @@ PR 本文は以下のテンプレート構造に従う。プロジェクトに `
 ## Checklist
 
 - [ ] PR タイトルが GitHub Release にそのまま載っても読める
-- [ ] 適切なラベルを付けた (`feature` / `fix` / `docs` / `chore` / ...)
+- [ ] 適切なラベルを付けた (`bug` / `enhancement` / `documentation` / `refactor` / `task` / ...)
 - [ ] ユーザー向け変更がある場合は `CHANGELOG.md` の `Unreleased` を更新した
 ```
 
 ### セクション埋め込みルール
 
-| セクション | 入力ソース | 記述ルール |
-|-----------|-----------|-----------|
-| Summary | コミット履歴 + diff stat | 変更内容を箇条書きで要約 |
-| Testing | テスト実行結果 | 実施済みなら結果を記載、未実施なら理由を記載 |
-| Release Note | 変更内容の分析 | ユーザー向け変更がある場合のみ記載 |
-| Checklist | 自動チェック | 可能な項目は事前にチェック済みにする |
+| セクション   | 入力ソース               | 記述ルール                                   |
+| ------------ | ------------------------ | -------------------------------------------- |
+| Summary      | コミット履歴 + diff stat | 変更内容を箇条書きで要約                     |
+| Testing      | テスト実行結果           | 実施済みなら結果を記載、未実施なら理由を記載 |
+| Release Note | 変更内容の分析           | ユーザー向け変更がある場合のみ記載           |
+| Checklist    | 自動チェック             | 可能な項目は事前にチェック済みにする         |
 
 ## PR タイトル
 
@@ -142,17 +142,21 @@ PR 本文は以下のテンプレート構造に従う。プロジェクトに `
 
 ## ブランチプレフィックスとラベルの対応
 
-| ブランチプレフィックス | PR タイトルプレフィックス | ラベル |
-|---------------------|----------------------|--------|
-| `fix/` | `fix:` | `fix` |
-| `feat/` | `feat:` | `feature` |
-| `docs/` | `docs:` | `docs` |
-| `chore/` | `chore:` | `chore` |
-| `refactor/` | `refactor:` | `refactor` |
-| `test/` | `test:` | `test` |
-| `task/` | `chore:` | `chore` |
-| `release/` | `release:` | `release` |
-| その他 | `chore:` | `chore` |
+ラベルは GitHub リポジトリで実際に定義されているものに合わせる。存在しないラベルを指定すると `gh pr create` がエラーを返すため、ポリシーと実リポジトリを同期させる。
+
+| ブランチプレフィックス | PR タイトルプレフィックス | ラベル          |
+| ---------------------- | ------------------------- | --------------- |
+| `fix/`                 | `fix:`                    | `bug`           |
+| `feat/`                | `feat:`                   | `enhancement`   |
+| `docs/`                | `docs:`                   | `documentation` |
+| `chore/`               | `chore:`                  | `task`          |
+| `refactor/`            | `refactor:`               | `refactor`      |
+| `test/`                | `test:`                   | `task`          |
+| `task/`                | `chore:`                  | `task`          |
+| `release/`             | `release:`                | `task`          |
+| その他                 | `chore:`                  | `task`          |
+
+> **Note**: `bug` / `enhancement` / `documentation` は GitHub のデフォルトラベルをそのまま採用している。`refactor` / `task` はプロジェクト固有ラベル。リポジトリが異なるラベル体系を使っている場合は、この表と実ラベルを個別に調整すること。
 
 ## Issue 連携
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `quality-gates/turn-end-summary.py` の Stop hook 出力が Claude Code のスキーマ違反（`hookSpecificOutput` は Stop では不可）となり `JSON validation failed` を起こしていた問題を修正。`systemMessage` フィールドに変更
+
 ## [0.2.4] - 2026-04-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- `pr-standards` ポリシーのブランチプレフィックス→ラベル対応表を GitHub の実ラベル体系 (`bug` / `enhancement` / `documentation` / `refactor` / `task`) に合わせて更新。`gh pr create` がラベル未存在で失敗する問題を解消 (`facets/policies/pr-standards.md`、`pr-create` / `issue-fix` スキル再生成)
+
 ### Fixed
 
 - `quality-gates/turn-end-summary.py` の Stop hook 出力が Claude Code のスキーマ違反（`hookSpecificOutput` は Stop では不可）となり `JSON validation failed` を起こしていた問題を修正。`systemMessage` フィールドに変更

--- a/facets/policies/pr-standards.md
+++ b/facets/policies/pr-standards.md
@@ -26,18 +26,18 @@ PR 本文は以下のテンプレート構造に従う。プロジェクトに `
 ## Checklist
 
 - [ ] PR タイトルが GitHub Release にそのまま載っても読める
-- [ ] 適切なラベルを付けた (`feature` / `fix` / `docs` / `chore` / ...)
+- [ ] 適切なラベルを付けた (`bug` / `enhancement` / `documentation` / `refactor` / `task` / ...)
 - [ ] ユーザー向け変更がある場合は `CHANGELOG.md` の `Unreleased` を更新した
 ```
 
 ### セクション埋め込みルール
 
-| セクション | 入力ソース | 記述ルール |
-|-----------|-----------|-----------|
-| Summary | コミット履歴 + diff stat | 変更内容を箇条書きで要約 |
-| Testing | テスト実行結果 | 実施済みなら結果を記載、未実施なら理由を記載 |
-| Release Note | 変更内容の分析 | ユーザー向け変更がある場合のみ記載 |
-| Checklist | 自動チェック | 可能な項目は事前にチェック済みにする |
+| セクション   | 入力ソース               | 記述ルール                                   |
+| ------------ | ------------------------ | -------------------------------------------- |
+| Summary      | コミット履歴 + diff stat | 変更内容を箇条書きで要約                     |
+| Testing      | テスト実行結果           | 実施済みなら結果を記載、未実施なら理由を記載 |
+| Release Note | 変更内容の分析           | ユーザー向け変更がある場合のみ記載           |
+| Checklist    | 自動チェック             | 可能な項目は事前にチェック済みにする         |
 
 ## PR タイトル
 
@@ -47,17 +47,21 @@ PR 本文は以下のテンプレート構造に従う。プロジェクトに `
 
 ## ブランチプレフィックスとラベルの対応
 
-| ブランチプレフィックス | PR タイトルプレフィックス | ラベル |
-|---------------------|----------------------|--------|
-| `fix/` | `fix:` | `fix` |
-| `feat/` | `feat:` | `feature` |
-| `docs/` | `docs:` | `docs` |
-| `chore/` | `chore:` | `chore` |
-| `refactor/` | `refactor:` | `refactor` |
-| `test/` | `test:` | `test` |
-| `task/` | `chore:` | `chore` |
-| `release/` | `release:` | `release` |
-| その他 | `chore:` | `chore` |
+ラベルは GitHub リポジトリで実際に定義されているものに合わせる。存在しないラベルを指定すると `gh pr create` がエラーを返すため、ポリシーと実リポジトリを同期させる。
+
+| ブランチプレフィックス | PR タイトルプレフィックス | ラベル          |
+| ---------------------- | ------------------------- | --------------- |
+| `fix/`                 | `fix:`                    | `bug`           |
+| `feat/`                | `feat:`                   | `enhancement`   |
+| `docs/`                | `docs:`                   | `documentation` |
+| `chore/`               | `chore:`                  | `task`          |
+| `refactor/`            | `refactor:`               | `refactor`      |
+| `test/`                | `test:`                   | `task`          |
+| `task/`                | `chore:`                  | `task`          |
+| `release/`             | `release:`                | `task`          |
+| その他                 | `chore:`                  | `task`          |
+
+> **Note**: `bug` / `enhancement` / `documentation` は GitHub のデフォルトラベルをそのまま採用している。`refactor` / `task` はプロジェクト固有ラベル。リポジトリが異なるラベル体系を使っている場合は、この表と実ラベルを個別に調整すること。
 
 ## Issue 連携
 

--- a/packages/quality-gates/hooks/turn-end-summary.py
+++ b/packages/quality-gates/hooks/turn-end-summary.py
@@ -259,12 +259,8 @@ def main() -> None:
     if not summary:
         return
 
-    output = {
-        "hookSpecificOutput": {
-            "hookEventName": "Stop",
-            "additionalContext": summary,
-        }
-    }
+    # Stop hook では hookSpecificOutput は許可されていないため systemMessage を使う
+    output = {"systemMessage": summary}
     print(json.dumps(output, ensure_ascii=False))
 
 

--- a/packages/quality-gates/tests/test_turn_end_summary.py
+++ b/packages/quality-gates/tests/test_turn_end_summary.py
@@ -124,13 +124,13 @@ class TestMain:
         output = self._invoke(payload, monkeypatch, capsys)
         assert output == ""
 
-    def test_outputs_additional_context(
+    def test_outputs_system_message(
         self,
         monkeypatch: pytest.MonkeyPatch,
         capsys: pytest.CaptureFixture[str],
         tmp_path: Path,
     ) -> None:
-        """Plans.md と working-context から additionalContext を組み立てることを確認する。"""
+        """Plans.md と working-context から systemMessage を組み立てることを確認する。"""
         claude_dir = tmp_path / ".claude"
         (claude_dir / "context" / "shared").mkdir(parents=True)
         (claude_dir / "context" / "shared" / "working-context.json").write_text(
@@ -147,7 +147,9 @@ class TestMain:
         output = self._invoke(payload, monkeypatch, capsys)
         assert output
         parsed = json.loads(output)
-        text = parsed["hookSpecificOutput"]["additionalContext"]
+        # Stop hook では hookSpecificOutput は許可されていないため systemMessage を使う
+        assert "hookSpecificOutput" not in parsed
+        text = parsed["systemMessage"]
         assert "Modified: 3 files" in text
         # main.py と server.ts はコード
         assert "code: 2" in text


### PR DESCRIPTION
## Summary

- **Stop hook スキーマ修正** (`packages/quality-gates/hooks/turn-end-summary.py`)
  - Claude Code の Stop hook が `hookSpecificOutput` を受け付けずスキーマ違反で `JSON validation failed` エラーを起こしていた問題を修正
  - 出力を `{"hookSpecificOutput": {...}}` から `{"systemMessage": summary}` に変更
  - テストに regression guard (`assert "hookSpecificOutput" not in parsed`) を追加
- **PR ラベル整合性修正** (`facets/policies/pr-standards.md` + 生成 SKILL.md)
  - ブランチプレフィックス→ラベル対応表が GitHub リポジトリに存在しないラベル (fix/feature/docs/chore/test/release) を指定しており `gh pr create` が label not found で失敗していた
  - 実ラベル (bug/enhancement/documentation/refactor/task) に更新
  - pr-create / issue-fix スキルの SKILL.md を再生成 (.claude/skills, .codex/skills)
- **orchestra.json 同期更新** (`.claude/orchestra.json`)
  - 配布対象エントリの順序整理と `last_sync` 更新

## Testing

- [x] テスト実施済み
- `pytest -q -k "turn_end_summary or lint_on_save"` → 22 passed
- ruff format / ruff check OK（PostToolUse lint hook で確認済み）
- ラベル更新は `gh label list` で実在確認済み

## Release Note

- ユーザー向け変更点:
  - Claude Code の Stop hook 発火時に `turn-end-summary.py` が出していた JSON スキーマエラーが解消され、ターンエンドサマリーが `systemMessage` として正しく表示されるようになります
  - `/pr-create` スキルが GitHub リポジトリに実在するラベルを自動付与するようになり、label not found エラーが解消されます
- `CHANGELOG.md` 更新: Unreleased の Fixed / Changed セクションに記載

## Checklist

- [x] PR タイトルが GitHub Release にそのまま載っても読める
- [x] 適切なラベルを付けた (`bug`)
- [x] ユーザー向け変更があるため `CHANGELOG.md` の `Unreleased` を更新した