### PR TITLE
chore: CONTEXT_SPECS を manifest の context_files から動的に構築

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changed
 
 - `pr-standards` ポリシーのブランチプレフィックス→ラベル対応表を GitHub の実ラベル体系 (`bug` / `enhancement` / `documentation` / `refactor` / `task`) に合わせて更新。`gh pr create` がラベル未存在で失敗する問題を解消 (`facets/policies/pr-standards.md`、`pr-create` / `issue-fix` スキル再生成)
+- `CONTEXT_SPECS` をパッケージ manifest の `context_files` から動的に構築するようリファクタ。`orchestra-manager.py` のハードコード定義を廃止し、`core` / `codex-suggestions` / `gemini-suggestions` の manifest に `source` / `template` キーを追加。`Package` dataclass に `context_files` フィールドを追加し、`init()` の hardcoded テンプレートコピーも init リストを SSOT とする whitelist 方式のデータ駆動ループに置換 (#45)
 
 ### Fixed
 

--- a/packages/codex-suggestions/manifest.json
+++ b/packages/codex-suggestions/manifest.json
@@ -4,8 +4,12 @@
   "description": "ファイル編集・プラン完了時の Codex 相談提案",
   "depends": ["core"],
   "hooks": {
-    "PreToolUse": [{"file": "check-codex-before-write.py", "matcher": "Edit|Write"}],
-    "PostToolUse": [{"file": "check-codex-after-plan.py", "matcher": "Agent|Task"}]
+    "PreToolUse": [
+      { "file": "check-codex-before-write.py", "matcher": "Edit|Write" }
+    ],
+    "PostToolUse": [
+      { "file": "check-codex-after-plan.py", "matcher": "Agent|Task" }
+    ]
   },
   "files": [
     "hooks/check-codex-before-write.py",
@@ -17,7 +21,13 @@
   "scripts": [],
   "config": [],
   "context_files": {
-    "init": ["AGENTS.md", ".codex/config.toml", ".codex/skills/context-loader/"],
+    "source": "codex.md",
+    "template": "templates/codex/AGENTS.md",
+    "init": [
+      "AGENTS.md",
+      ".codex/config.toml",
+      ".codex/skills/context-loader/"
+    ],
     "sync": ["AGENTS.md"]
   }
 }

--- a/packages/core/manifest.json
+++ b/packages/core/manifest.json
@@ -49,5 +49,11 @@
     "escalation-strategy"
   ],
   "scripts": [],
-  "config": ["config/task-memory.yaml"]
+  "config": ["config/task-memory.yaml"],
+  "context_files": {
+    "source": "claude.md",
+    "template": "templates/project/CLAUDE.md",
+    "init": ["CLAUDE.md"],
+    "sync": ["CLAUDE.md"]
+  }
 }

--- a/packages/gemini-suggestions/manifest.json
+++ b/packages/gemini-suggestions/manifest.json
@@ -4,18 +4,24 @@
   "description": "Web 検索・fetch 時の Gemini リサーチ提案",
   "depends": ["core"],
   "hooks": {
-    "PreToolUse": [{"file": "suggest-gemini-research.py", "matcher": "WebSearch|WebFetch"}]
+    "PreToolUse": [
+      { "file": "suggest-gemini-research.py", "matcher": "WebSearch|WebFetch" }
+    ]
   },
-  "files": [
-    "hooks/suggest-gemini-research.py"
-  ],
+  "files": ["hooks/suggest-gemini-research.py"],
   "skills": ["gemini-system"],
   "agents": [],
   "rules": ["gemini-delegation", "gemini-suggestion-compliance"],
   "scripts": [],
   "config": [],
   "context_files": {
-    "init": [".gemini/GEMINI.md", ".gemini/settings.json", ".gemini/skills/context-loader/"],
+    "source": "gemini.md",
+    "template": "templates/gemini/GEMINI.md",
+    "init": [
+      ".gemini/GEMINI.md",
+      ".gemini/settings.json",
+      ".gemini/skills/context-loader/"
+    ],
     "sync": [".gemini/GEMINI.md"]
   }
 }

--- a/scripts/lib/orchestra_models.py
+++ b/scripts/lib/orchestra_models.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
@@ -44,6 +44,7 @@ class Package:
     agents: list[str]
     rules: list[str]
     path: Path
+    context_files: dict[str, Any] = field(default_factory=dict)
 
     @classmethod
     def load(cls, manifest_path: Path) -> Package:
@@ -68,4 +69,5 @@ class Package:
             agents=data.get("agents", []),
             rules=data.get("rules", []),
             path=manifest_path.parent,
+            context_files=data.get("context_files", {}),
         )

--- a/scripts/orchestra-manager.py
+++ b/scripts/orchestra-manager.py
@@ -15,6 +15,7 @@ import shutil
 import subprocess
 import sys
 from collections import deque
+from functools import cached_property  # noqa: F401 — used as decorator
 from pathlib import Path
 from typing import Any
 
@@ -36,18 +37,6 @@ class OrchestraManager(ContextMixin, HooksMixin):
 
     SYNC_HOOK_COMMAND = 'python3 "$AI_ORCHESTRA_DIR/scripts/sync-orchestra.py"'
     SYNC_HOOK_TIMEOUT = 15
-    # gitignore エントリは gitignore_sync モジュールで一元管理
-    CONTEXT_SPECS: tuple[tuple[str, str, str, str, str | None], ...] = (
-        ("claude", "claude.md", "templates/project/CLAUDE.md", "CLAUDE.md", None),
-        ("codex", "codex.md", "templates/codex/AGENTS.md", "AGENTS.md", "codex-suggestions"),
-        (
-            "gemini",
-            "gemini.md",
-            "templates/gemini/GEMINI.md",
-            ".gemini/GEMINI.md",
-            "gemini-suggestions",
-        ),
-    )
     CONTEXT_SHARED_REL = "templates/context/shared.md"
     COLOR_RESET = "\033[0m"
     COLOR_GREEN = "\033[32m"
@@ -59,6 +48,36 @@ class OrchestraManager(ContextMixin, HooksMixin):
         self.orchestra_dir = orchestra_dir
         self.packages_dir = orchestra_dir / "packages"
         self.use_color = sys.stdout.isatty() and os.getenv("NO_COLOR") is None
+
+    def _build_context_specs(self) -> tuple[tuple[str, str, str, str, str | None], ...]:
+        """manifest の context_files から CONTEXT_SPECS を動的に構築する。
+
+        core は常に先頭（CLAUDE.md を最初に処理）、その他はパッケージ名の昇順。
+        core の context は required_package=None で常時配布扱い。
+        """
+        packages = self.load_packages()
+        specs_with_pkg: list[tuple[str, tuple[str, str, str, str, str | None]]] = []
+        for pkg_name, pkg in packages.items():
+            cf = pkg.context_files
+            if not cf:
+                continue
+            source = cf.get("source")
+            template = cf.get("template")
+            sync_list = cf.get("sync") or []
+            if not source or not template or not sync_list:
+                continue
+            project_rel = sync_list[0]
+            required: str | None = None if pkg.name == "core" else pkg.name
+            name = Path(source).stem
+            specs_with_pkg.append((pkg_name, (name, source, template, project_rel, required)))
+        # core first (owns claude.md), then alphabetical by package name
+        specs_with_pkg.sort(key=lambda item: (0 if item[0] == "core" else 1, item[0]))
+        return tuple(spec for _, spec in specs_with_pkg)
+
+    @cached_property
+    def CONTEXT_SPECS(self) -> tuple[tuple[str, str, str, str, str | None], ...]:
+        """manifest.context_files から動的構築された context spec タプル。"""
+        return self._build_context_specs()
 
     def colorize(self, text: str, color: str | None) -> str:
         """色付き文字列を返す（非TTY/NO_COLORでは無効）"""
@@ -327,6 +346,59 @@ class OrchestraManager(ContextMixin, HooksMixin):
         if synced_count > 0:
             print(f"{synced_count} ファイルを同期しました")
 
+    def _install_context_init_files(self, pkg: Package, project_dir: Path, dry_run: bool) -> None:
+        """manifest.context_files.init に基づきテンプレートを初回配置する。
+
+        init リスト内のエントリを SSOT として扱い、リストに列挙されたパスだけを
+        コピーする。rglob ベースの一括コピーは行わない。
+        """
+        cf = pkg.context_files or {}
+        init_entries: list[str] = cf.get("init") or []
+        template_rel = cf.get("template")
+        if not init_entries or not template_rel:
+            return
+
+        template_file = self.orchestra_dir / template_rel
+        template_root = template_file.parent
+        if not template_root.is_dir():
+            print(
+                f"警告: テンプレートディレクトリが見つかりません: {template_root}",
+                file=sys.stderr,
+            )
+            return
+
+        for entry in init_entries:
+            is_dir = entry.endswith("/")
+            entry_clean = entry.rstrip("/")
+            if not entry_clean:
+                continue
+
+            if "/" in entry_clean:
+                # プレフィックス付き: .codex/config.toml → src は templates/codex/config.toml
+                _, rest = entry_clean.split("/", 1)
+                src = template_root / rest
+            else:
+                # ルート直下: AGENTS.md や CLAUDE.md
+                src = template_root / entry_clean
+
+            dst = project_dir / entry_clean
+            label = entry_clean
+
+            if is_dir:
+                if not src.is_dir():
+                    continue
+                for src_file in src.rglob("*"):
+                    if not src_file.is_file():
+                        continue
+                    file_rel = src_file.relative_to(src)
+                    self._copy_template_if_missing(
+                        src_file, dst / file_rel, f"{label}/{file_rel}", dry_run
+                    )
+            else:
+                if not src.is_file():
+                    continue
+                self._copy_template_if_missing(src, dst, label, dry_run)
+
     def _copy_template_if_missing(
         self, src: Path, dst: Path, label: str, dry_run: bool = False
     ) -> bool:
@@ -532,12 +604,6 @@ class OrchestraManager(ContextMixin, HooksMixin):
             self._copy_template_if_missing(src, dst, str(dst.relative_to(project_dir)), dry_run)
 
         self._copy_template_if_missing(
-            templates_dir / "project" / "CLAUDE.md",
-            project_dir / "CLAUDE.md",
-            "CLAUDE.md",
-            dry_run,
-        )
-        self._copy_template_if_missing(
             templates_dir / "project" / ".claudeignore",
             project_dir / ".claudeignore",
             ".claudeignore",
@@ -549,33 +615,13 @@ class OrchestraManager(ContextMixin, HooksMixin):
         orch = self.load_orchestra_json(project_dir)
         installed = set(orch.get("installed_packages", []))
 
-        # AGENTS.md はプロジェクトルートに配置（Codex は .codex/ 内ではなくルートを読む）
-        if "codex-suggestions" in installed:
-            codex_src = templates_dir / "codex"
-            codex_root_files = {"AGENTS.md"}
-            if codex_src.is_dir():
-                codex_dst = project_dir / ".codex"
-                for src_file in codex_src.rglob("*"):
-                    if not src_file.is_file():
-                        continue
-                    rel = src_file.relative_to(codex_src)
-                    if rel.name in codex_root_files:
-                        dst_file = project_dir / rel.name
-                        label = rel.name
-                    else:
-                        dst_file = codex_dst / rel
-                        label = f".codex/{rel}"
-                    self._copy_template_if_missing(src_file, dst_file, label, dry_run)
-
-        if "gemini-suggestions" in installed:
-            gemini_src = templates_dir / "gemini"
-            if gemini_src.is_dir():
-                for src_file in gemini_src.rglob("*"):
-                    if not src_file.is_file():
-                        continue
-                    rel = src_file.relative_to(gemini_src)
-                    dst_file = project_dir / ".gemini" / rel
-                    self._copy_template_if_missing(src_file, dst_file, f".gemini/{rel}", dry_run)
+        packages_map = self.load_packages()
+        installed_with_core = set(installed) | {"core"}
+        for pkg_name in sorted(installed_with_core):
+            pkg = packages_map.get(pkg_name)
+            if pkg is None or not pkg.context_files:
+                continue
+            self._install_context_init_files(pkg, project_dir, dry_run)
 
         if not orch.get("orchestra_dir"):
             orch["orchestra_dir"] = str(self.orchestra_dir)

--- a/tests/unit/test_orchestra_manager_context.py
+++ b/tests/unit/test_orchestra_manager_context.py
@@ -5,6 +5,52 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+
+def _setup_context_packages(orchestra_dir: Path) -> None:
+    """context_files を含む minimal manifest を作成する。"""
+    packages = {
+        "core": {
+            "name": "core",
+            "version": "0.0.0",
+            "depends": [],
+            "context_files": {
+                "source": "claude.md",
+                "template": "templates/project/CLAUDE.md",
+                "init": ["CLAUDE.md"],
+                "sync": ["CLAUDE.md"],
+            },
+        },
+        "codex-suggestions": {
+            "name": "codex-suggestions",
+            "version": "0.0.0",
+            "depends": [],
+            "context_files": {
+                "source": "codex.md",
+                "template": "templates/codex/AGENTS.md",
+                "init": ["AGENTS.md"],
+                "sync": ["AGENTS.md"],
+            },
+        },
+        "gemini-suggestions": {
+            "name": "gemini-suggestions",
+            "version": "0.0.0",
+            "depends": [],
+            "context_files": {
+                "source": "gemini.md",
+                "template": "templates/gemini/GEMINI.md",
+                "init": [".gemini/GEMINI.md"],
+                "sync": [".gemini/GEMINI.md"],
+            },
+        },
+    }
+    packages_dir = orchestra_dir / "packages"
+    packages_dir.mkdir(parents=True, exist_ok=True)
+    for pkg_name, manifest in packages.items():
+        pkg_dir = packages_dir / pkg_name
+        pkg_dir.mkdir(parents=True, exist_ok=True)
+        (pkg_dir / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+
+
 import pytest
 
 from tests.module_loader import load_module
@@ -21,6 +67,8 @@ def _setup_context_sources(orchestra_dir: Path) -> None:
     (context_dir / "claude.md").write_text("# CLAUDE\n\nclaude body\n", encoding="utf-8")
     (context_dir / "codex.md").write_text("# AGENTS\n\ncodex body\n", encoding="utf-8")
     (context_dir / "gemini.md").write_text("# GEMINI\n\ngemini body\n", encoding="utf-8")
+
+    _setup_context_packages(orchestra_dir)
 
 
 def _setup_orchestra_json(
@@ -198,3 +246,199 @@ class TestContextSync:
         assert (project_dir / "CLAUDE.md").is_file()
         assert not (project_dir / "AGENTS.md").exists()
         assert not (project_dir / ".gemini" / "GEMINI.md").exists()
+
+
+class TestInstallContextInitFiles:
+    def test_root_file_is_copied(self, tmp_path: Path) -> None:
+        orchestra_dir = tmp_path / "orchestra"
+        project_dir = tmp_path / "project"
+        project_dir.mkdir(parents=True)
+
+        tmpl = orchestra_dir / "templates" / "project" / "CLAUDE.md"
+        tmpl.parent.mkdir(parents=True, exist_ok=True)
+        tmpl.write_text("claude content", encoding="utf-8")
+
+        pkg_dir = orchestra_dir / "packages" / "core"
+        pkg_dir.mkdir(parents=True, exist_ok=True)
+        manifest = {
+            "name": "core",
+            "version": "0.0.0",
+            "depends": [],
+            "context_files": {
+                "source": "claude.md",
+                "template": "templates/project/CLAUDE.md",
+                "init": ["CLAUDE.md"],
+                "sync": ["CLAUDE.md"],
+            },
+        }
+        (pkg_dir / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+
+        manager = OrchestraManager(orchestra_dir)
+        pkg = manager.load_packages()["core"]
+        manager._install_context_init_files(pkg, project_dir, dry_run=False)
+
+        dest = project_dir / "CLAUDE.md"
+        assert dest.is_file()
+        assert dest.read_text(encoding="utf-8") == "claude content"
+
+    def test_prefixed_file_is_copied(self, tmp_path: Path) -> None:
+        orchestra_dir = tmp_path / "orchestra"
+        project_dir = tmp_path / "project"
+        project_dir.mkdir(parents=True)
+
+        tmpl_dir = orchestra_dir / "templates" / "codex"
+        tmpl_dir.mkdir(parents=True, exist_ok=True)
+        (tmpl_dir / "AGENTS.md").write_text("agents content", encoding="utf-8")
+        (tmpl_dir / "config.toml").write_text("toml content", encoding="utf-8")
+
+        pkg_dir = orchestra_dir / "packages" / "codex-suggestions"
+        pkg_dir.mkdir(parents=True, exist_ok=True)
+        manifest = {
+            "name": "codex-suggestions",
+            "version": "0.0.0",
+            "depends": [],
+            "context_files": {
+                "source": "codex.md",
+                "template": "templates/codex/AGENTS.md",
+                "init": ["AGENTS.md", ".codex/config.toml"],
+                "sync": ["AGENTS.md"],
+            },
+        }
+        (pkg_dir / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+
+        manager = OrchestraManager(orchestra_dir)
+        pkg = manager.load_packages()["codex-suggestions"]
+        manager._install_context_init_files(pkg, project_dir, dry_run=False)
+
+        assert (project_dir / "AGENTS.md").is_file()
+        toml_dest = project_dir / ".codex" / "config.toml"
+        assert toml_dest.is_file()
+        assert toml_dest.read_text(encoding="utf-8") == "toml content"
+
+    def test_directory_entry_is_copied_recursively(self, tmp_path: Path) -> None:
+        orchestra_dir = tmp_path / "orchestra"
+        project_dir = tmp_path / "project"
+        project_dir.mkdir(parents=True)
+
+        tmpl_dir = orchestra_dir / "templates" / "codex"
+        tmpl_dir.mkdir(parents=True, exist_ok=True)
+        (tmpl_dir / "AGENTS.md").write_text("placeholder", encoding="utf-8")
+
+        skill_dir = tmpl_dir / "skills" / "context-loader"
+        skill_dir.mkdir(parents=True, exist_ok=True)
+        (skill_dir / "SKILL.md").write_text("skill content", encoding="utf-8")
+
+        pkg_dir = orchestra_dir / "packages" / "codex-suggestions"
+        pkg_dir.mkdir(parents=True, exist_ok=True)
+        manifest = {
+            "name": "codex-suggestions",
+            "version": "0.0.0",
+            "depends": [],
+            "context_files": {
+                "source": "codex.md",
+                "template": "templates/codex/AGENTS.md",
+                "init": [".codex/skills/context-loader/"],
+                "sync": ["AGENTS.md"],
+            },
+        }
+        (pkg_dir / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+
+        manager = OrchestraManager(orchestra_dir)
+        pkg = manager.load_packages()["codex-suggestions"]
+        manager._install_context_init_files(pkg, project_dir, dry_run=False)
+
+        dest = project_dir / ".codex" / "skills" / "context-loader" / "SKILL.md"
+        assert dest.is_file()
+        assert dest.read_text(encoding="utf-8") == "skill content"
+
+    def test_missing_template_root_prints_warning_and_no_crash(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        orchestra_dir = tmp_path / "orchestra"
+        project_dir = tmp_path / "project"
+        project_dir.mkdir(parents=True)
+
+        pkg_dir = orchestra_dir / "packages" / "core"
+        pkg_dir.mkdir(parents=True, exist_ok=True)
+        manifest = {
+            "name": "core",
+            "version": "0.0.0",
+            "depends": [],
+            "context_files": {
+                "source": "claude.md",
+                "template": "templates/nonexistent/FILE.md",
+                "init": ["FILE.md"],
+                "sync": [],
+            },
+        }
+        (pkg_dir / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+
+        manager = OrchestraManager(orchestra_dir)
+        pkg = manager.load_packages()["core"]
+        manager._install_context_init_files(pkg, project_dir, dry_run=False)
+
+        captured = capsys.readouterr()
+        assert "テンプレートディレクトリ" in captured.err
+
+    def test_existing_file_is_not_overwritten(self, tmp_path: Path) -> None:
+        orchestra_dir = tmp_path / "orchestra"
+        project_dir = tmp_path / "project"
+        project_dir.mkdir(parents=True)
+
+        tmpl = orchestra_dir / "templates" / "project" / "CLAUDE.md"
+        tmpl.parent.mkdir(parents=True, exist_ok=True)
+        tmpl.write_text("new content", encoding="utf-8")
+
+        existing = project_dir / "CLAUDE.md"
+        existing.write_text("existing content", encoding="utf-8")
+
+        pkg_dir = orchestra_dir / "packages" / "core"
+        pkg_dir.mkdir(parents=True, exist_ok=True)
+        manifest = {
+            "name": "core",
+            "version": "0.0.0",
+            "depends": [],
+            "context_files": {
+                "source": "claude.md",
+                "template": "templates/project/CLAUDE.md",
+                "init": ["CLAUDE.md"],
+                "sync": ["CLAUDE.md"],
+            },
+        }
+        (pkg_dir / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+
+        manager = OrchestraManager(orchestra_dir)
+        pkg = manager.load_packages()["core"]
+        manager._install_context_init_files(pkg, project_dir, dry_run=False)
+
+        assert existing.read_text(encoding="utf-8") == "existing content"
+
+    def test_empty_init_list_is_noop(self, tmp_path: Path) -> None:
+        orchestra_dir = tmp_path / "orchestra"
+        project_dir = tmp_path / "project"
+        project_dir.mkdir(parents=True)
+
+        tmpl = orchestra_dir / "templates" / "project" / "CLAUDE.md"
+        tmpl.parent.mkdir(parents=True, exist_ok=True)
+        tmpl.write_text("content", encoding="utf-8")
+
+        pkg_dir = orchestra_dir / "packages" / "core"
+        pkg_dir.mkdir(parents=True, exist_ok=True)
+        manifest = {
+            "name": "core",
+            "version": "0.0.0",
+            "depends": [],
+            "context_files": {
+                "source": "claude.md",
+                "template": "templates/project/CLAUDE.md",
+                "init": [],
+                "sync": ["CLAUDE.md"],
+            },
+        }
+        (pkg_dir / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+
+        manager = OrchestraManager(orchestra_dir)
+        pkg = manager.load_packages()["core"]
+        manager._install_context_init_files(pkg, project_dir, dry_run=False)
+
+        assert list(project_dir.iterdir()) == []


### PR DESCRIPTION
Closes #45

## Summary

- `orchestra-manager.py` のハードコードされた `CONTEXT_SPECS` タプルを廃止し、パッケージ manifest の `context_files` 宣言を SSOT として実行時に動的構築するようリファクタ
- `core` / `codex-suggestions` / `gemini-suggestions` の manifest に `source` / `template` キーを追加
- `Package` dataclass に `context_files` フィールドを追加し `Package.load()` で読み込み
- `init()` の hardcoded `.codex/` `.gemini/` テンプレートコピーを `context_files.init` の whitelist 方式に置換
- `_install_context_init_files` の単体テスト 6 件を新規追加（root / prefix / directory / missing / skip / noop）

## Testing

- [x] `pytest -q` — 1161 passed, 17 skipped
- [x] `ruff check scripts/ tests/` — all passed
- [x] `orchex context build/check/sync` — 正常動作確認済み
- [x] code-reviewer / architecture-reviewer でレビュー実施、Critical 1 + High 2 を修正済み

## Release Note

- ユーザー向け変更点: なし（内部リファクタリング）
- `CHANGELOG.md` 更新: 済（Unreleased の Changed セクション）

## Checklist

- [x] PR タイトルが GitHub Release にそのまま載っても読める
- [x] 適切なラベルを付けた (`task`)
- [x] `CHANGELOG.md` の `Unreleased` を更新した

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **その他**
  * パッケージのコンテキストファイル管理システムを改善しました。
  * 設定構造を更新し、パッケージごとのコンテキストファイル設定がより柔軟に対応できるようになりました。
  * コンテキストファイルの初期化プロセスが最適化されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->