### PR TITLE
feat: ツール選択最適化 Hook の実装 (#10)

### DIFF
--- a/.claude/config/audit/audit-flags.json
+++ b/.claude/config/audit/audit-flags.json
@@ -12,6 +12,11 @@
     "kpi_scorecard": {
       "enabled": true,
       "default_period_days": 7
+    },
+    "context_optimization": {
+      "enabled": true,
+      "read_line_threshold": 200,
+      "max_file_size_bytes": 5242880
     }
   },
   "paths": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   - `quality-gates/turn-end-summary.py`: Stop イベントでターン終了サマリーを注入
     （編集ファイル数、Plans.md の WIP/TODO/blocked 件数、lint 未実行リマインダー）
   - audit 統一スキーマに `instructions_loaded`, `turn_end`, `precompact` イベント型を追加
+- `quality-gates/check-context-optimization.py`: PreToolUse(Read|Grep|Bash) で非効率な
+  ツール使用 (Read 全文読み・Grep content モード乱用・Bash の cat/grep/find 等) を検出し、
+  エスカレーション戦略への切り替えを提案する Hook を追加 (#10)
+  - `audit-flags.json` に `features.context_optimization` フラグを追加（閾値・無効化対応）
 
 ### Changed
 

--- a/packages/audit/config/audit-flags.json
+++ b/packages/audit/config/audit-flags.json
@@ -12,6 +12,11 @@
     "kpi_scorecard": {
       "enabled": true,
       "default_period_days": 7
+    },
+    "context_optimization": {
+      "enabled": true,
+      "read_line_threshold": 200,
+      "max_file_size_bytes": 5242880
     }
   },
   "paths": {

--- a/packages/quality-gates/hooks/check-context-optimization.py
+++ b/packages/quality-gates/hooks/check-context-optimization.py
@@ -38,6 +38,9 @@ BASH_REPLACEMENTS: dict[str, str] = {
     "rg": "Grep",
 }
 
+# 検出時に剥がして次トークンを評価する単純なラッパー
+BASH_WRAPPER_PREFIXES: frozenset[str] = frozenset({"sudo", "time", "nice"})
+
 ESCALATION_REF = "参照: .claude/rules/escalation-strategy.md"
 
 _MESSAGE_VALUE_MAX_LEN = 200
@@ -93,9 +96,6 @@ def check_read(tool_input: dict, settings: dict) -> str:
     threshold = int(settings.get("read_line_threshold", DEFAULT_READ_LINE_THRESHOLD))
     max_bytes = int(settings.get("max_file_size_bytes", DEFAULT_MAX_FILE_SIZE_BYTES))
 
-    if not os.path.isfile(file_path):
-        return ""
-
     line_count = _count_lines(file_path, max_bytes)
     if line_count is None or line_count <= threshold:
         return ""
@@ -125,22 +125,25 @@ def check_grep(tool_input: dict, _settings: dict) -> str:
 
 
 def _bash_replacement(command: str) -> tuple[str, str]:
-    """command の先頭トークンを解析し、(検出されたコマンド, 推奨ツール) を返す。"""
+    """command の先頭トークンを解析し、(検出されたコマンド, 推奨ツール) を返す。
+
+    `sudo cat foo` や `sudo nice cat foo` のような連続ラッパーは
+    BASH_WRAPPER_PREFIXES に含まれる限り何段でも剥がして次のトークンを評価する。
+    """
     if not command:
         return "", ""
     try:
         tokens = shlex.split(command, comments=False, posix=True)
     except ValueError:
         return "", ""
-    if not tokens:
+
+    idx = 0
+    while idx < len(tokens) and os.path.basename(tokens[idx]) in BASH_WRAPPER_PREFIXES:
+        idx += 1
+    if idx >= len(tokens):
         return "", ""
 
-    head = tokens[0]
-    # `sudo cat foo.py` のような呼び出しも拾う
-    if head in {"sudo", "time", "nice"} and len(tokens) > 1:
-        head = tokens[1]
-
-    base = os.path.basename(head)
+    base = os.path.basename(tokens[idx])
     if base in BASH_REPLACEMENTS:
         return base, BASH_REPLACEMENTS[base]
     return "", ""

--- a/packages/quality-gates/hooks/check-context-optimization.py
+++ b/packages/quality-gates/hooks/check-context-optimization.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""
+PreToolUse hook: Suggest context-saving alternatives for Read / Grep / Bash.
+
+非効率なツール使用 (Read 全文読み・Grep content モード乱用・Bash の cat/grep 等)
+を検出し、エスカレーション戦略への切り替えを提案する。
+
+参照: .claude/rules/escalation-strategy.md
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import stat
+import sys
+
+# hook_common を $AI_ORCHESTRA_DIR/packages/core/hooks/ から読み込む
+_orchestra_dir = os.environ.get("AI_ORCHESTRA_DIR", "")
+if _orchestra_dir:
+    _core_hooks = os.path.join(_orchestra_dir, "packages", "core", "hooks")
+    if _core_hooks not in sys.path:
+        sys.path.insert(0, _core_hooks)
+
+from hook_common import load_package_config  # noqa: E402
+
+DEFAULT_READ_LINE_THRESHOLD = 200
+DEFAULT_MAX_FILE_SIZE_BYTES = 5 * 1024 * 1024  # 5 MB
+
+# Bash で代替が望ましい先頭コマンド → 提案する代替ツール
+BASH_REPLACEMENTS: dict[str, str] = {
+    "cat": "Read",
+    "head": "Read (offset/limit 指定)",
+    "tail": "Read (末尾は offset で指定)",
+    "find": "Glob",
+    "grep": "Grep",
+    "rg": "Grep",
+}
+
+ESCALATION_REF = "参照: .claude/rules/escalation-strategy.md"
+
+_MESSAGE_VALUE_MAX_LEN = 200
+
+
+def _sanitize_for_message(value: str, max_len: int = _MESSAGE_VALUE_MAX_LEN) -> str:
+    """改行・制御文字を除去し、メッセージ埋め込み用に切り詰めた文字列を返す。"""
+    cleaned = "".join(ch if ch.isprintable() else " " for ch in value)
+    if len(cleaned) > max_len:
+        cleaned = cleaned[: max_len - 3] + "..."
+    return cleaned
+
+
+def _load_settings(project_dir: str) -> dict:
+    """audit-flags.json から context_optimization 設定を取り出す。"""
+    config = load_package_config("audit", "audit-flags.json", project_dir)
+    return config.get("features", {}).get("context_optimization", {}) or {}
+
+
+def is_enabled(settings: dict) -> bool:
+    """context_optimization 機能が有効かどうかを返す。デフォルト ON。"""
+    return bool(settings.get("enabled", True))
+
+
+def _count_lines(path: str, max_bytes: int) -> int | None:
+    """通常ファイルの行数を返す。サイズ超過・特殊ファイル・I/O 失敗時は None。"""
+    try:
+        st = os.stat(path, follow_symlinks=True)
+    except OSError:
+        return None
+    if not stat.S_ISREG(st.st_mode):
+        return None
+    if st.st_size > max_bytes:
+        return None
+    try:
+        with open(path, "rb") as f:
+            return sum(1 for _ in f)
+    except OSError:
+        return None
+
+
+def check_read(tool_input: dict, settings: dict) -> str:
+    """Read 呼び出しを検査し、提案メッセージ (空文字なら提案なし) を返す。"""
+    file_path = tool_input.get("file_path", "")
+    if not file_path:
+        return ""
+
+    has_offset = tool_input.get("offset") is not None
+    has_limit = tool_input.get("limit") is not None
+    if has_offset or has_limit:
+        return ""
+
+    threshold = int(settings.get("read_line_threshold", DEFAULT_READ_LINE_THRESHOLD))
+    max_bytes = int(settings.get("max_file_size_bytes", DEFAULT_MAX_FILE_SIZE_BYTES))
+
+    if not os.path.isfile(file_path):
+        return ""
+
+    line_count = _count_lines(file_path, max_bytes)
+    if line_count is None or line_count <= threshold:
+        return ""
+
+    return (
+        f"[Context Optimization] Read で {line_count} 行のファイルを全文読み込もうとしています。\n"
+        "  → offset/limit を指定して必要範囲のみ部分読み込みを検討してください。\n"
+        f"  → {ESCALATION_REF}"
+    )
+
+
+def check_grep(tool_input: dict, _settings: dict) -> str:
+    """Grep 呼び出しを検査し、提案メッセージを返す。"""
+    output_mode = tool_input.get("output_mode", "files_with_matches")
+    if output_mode != "content":
+        return ""
+    if tool_input.get("head_limit") is not None:
+        return ""
+
+    pattern_excerpt = _sanitize_for_message(tool_input.get("pattern", ""), max_len=60)
+    return (
+        "[Context Optimization] Grep を content モードで head_limit 指定なしで実行しようとしています "
+        f"(pattern: {pattern_excerpt!r})。\n"
+        "  → まず output_mode='count' でマッチ件数を把握し、head_limit を設定してください。\n"
+        f"  → {ESCALATION_REF}"
+    )
+
+
+def _bash_replacement(command: str) -> tuple[str, str]:
+    """command の先頭トークンを解析し、(検出されたコマンド, 推奨ツール) を返す。"""
+    if not command:
+        return "", ""
+    try:
+        tokens = shlex.split(command, comments=False, posix=True)
+    except ValueError:
+        return "", ""
+    if not tokens:
+        return "", ""
+
+    head = tokens[0]
+    # `sudo cat foo.py` のような呼び出しも拾う
+    if head in {"sudo", "time", "nice"} and len(tokens) > 1:
+        head = tokens[1]
+
+    base = os.path.basename(head)
+    if base in BASH_REPLACEMENTS:
+        return base, BASH_REPLACEMENTS[base]
+    return "", ""
+
+
+def check_bash(tool_input: dict, _settings: dict) -> str:
+    """Bash 呼び出しを検査し、専用ツール推奨メッセージを返す。"""
+    command = tool_input.get("command", "")
+    used, replacement = _bash_replacement(command)
+    if not used:
+        return ""
+
+    used_safe = _sanitize_for_message(used, max_len=40)
+    return (
+        f"[Context Optimization] Bash で `{used_safe}` を使用しようとしています。\n"
+        f"  → 代わりに {replacement} を使うと出力サイズを制御できます。\n"
+        f"  → {ESCALATION_REF}"
+    )
+
+
+CHECKERS = {
+    "Read": check_read,
+    "Grep": check_grep,
+    "Bash": check_bash,
+}
+
+
+def main() -> None:
+    try:
+        data = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        sys.exit(0)
+
+    project_dir = data.get("cwd", "") or os.environ.get("CLAUDE_PROJECT_DIR", "")
+    settings = _load_settings(project_dir)
+    if not is_enabled(settings):
+        sys.exit(0)
+
+    tool_name = data.get("tool_name", "")
+    checker = CHECKERS.get(tool_name)
+    if checker is None:
+        sys.exit(0)
+
+    tool_input = data.get("tool_input", {}) or {}
+    try:
+        message = checker(tool_input, settings)
+    except Exception as exc:
+        print(f"check-context-optimization error: {exc}", file=sys.stderr)
+        sys.exit(0)
+
+    if not message:
+        sys.exit(0)
+
+    output = {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "additionalContext": message,
+        }
+    }
+    print(json.dumps(output))
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/quality-gates/manifest.json
+++ b/packages/quality-gates/manifest.json
@@ -4,6 +4,9 @@
   "description": "実装後レビュー・テスト分析・自動 lint の品質ゲート",
   "depends": ["core"],
   "hooks": {
+    "PreToolUse": [
+      {"file": "check-context-optimization.py", "matcher": "Read|Grep|Bash"}
+    ],
     "PostToolUse": [
       {"file": "post-implementation-review.py", "matcher": "Edit|Write"},
       {"file": "post-test-analysis.py", "matcher": "Bash"},
@@ -13,6 +16,7 @@
     "Stop": ["turn-end-summary.py"]
   },
   "files": [
+    "hooks/check-context-optimization.py",
     "hooks/post-implementation-review.py",
     "hooks/post-test-analysis.py",
     "hooks/lint-on-save.py",

--- a/packages/quality-gates/manifest.json
+++ b/packages/quality-gates/manifest.json
@@ -2,7 +2,7 @@
   "name": "quality-gates",
   "version": "0.1.0",
   "description": "実装後レビュー・テスト分析・自動 lint の品質ゲート",
-  "depends": ["core"],
+  "depends": ["core", "audit"],
   "hooks": {
     "PreToolUse": [
       {"file": "check-context-optimization.py", "matcher": "Read|Grep|Bash"}

--- a/packages/quality-gates/tests/test_check_context_optimization.py
+++ b/packages/quality-gates/tests/test_check_context_optimization.py
@@ -1,0 +1,204 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from tests.module_loader import load_module
+
+check_context_optimization = load_module(
+    "check_context_optimization",
+    "packages/quality-gates/hooks/check-context-optimization.py",
+)
+
+
+def _settings(**overrides) -> dict:
+    base = {"enabled": True, "read_line_threshold": 200, "max_file_size_bytes": 5_242_880}
+    base.update(overrides)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# is_enabled
+# ---------------------------------------------------------------------------
+
+
+def test_is_enabled_default_true_when_missing() -> None:
+    assert check_context_optimization.is_enabled({}) is True
+
+
+def test_is_enabled_explicit_false() -> None:
+    assert check_context_optimization.is_enabled({"enabled": False}) is False
+
+
+# ---------------------------------------------------------------------------
+# check_read
+# ---------------------------------------------------------------------------
+
+
+def test_check_read_returns_empty_when_file_missing(tmp_path: Path) -> None:
+    msg = check_context_optimization.check_read(
+        {"file_path": str(tmp_path / "missing.txt")}, _settings()
+    )
+    assert msg == ""
+
+
+def test_check_read_returns_empty_when_offset_only(tmp_path: Path) -> None:
+    target = tmp_path / "big.txt"
+    target.write_text("\n".join(str(i) for i in range(500)))
+    msg = check_context_optimization.check_read(
+        {"file_path": str(target), "offset": 1}, _settings()
+    )
+    assert msg == ""
+
+
+def test_check_read_returns_empty_when_limit_only(tmp_path: Path) -> None:
+    target = tmp_path / "big.txt"
+    target.write_text("\n".join(str(i) for i in range(500)))
+    msg = check_context_optimization.check_read(
+        {"file_path": str(target), "limit": 50}, _settings()
+    )
+    assert msg == ""
+
+
+def test_check_read_returns_empty_for_small_file(tmp_path: Path) -> None:
+    target = tmp_path / "small.txt"
+    target.write_text("\n".join(str(i) for i in range(50)))
+    msg = check_context_optimization.check_read({"file_path": str(target)}, _settings())
+    assert msg == ""
+
+
+def test_check_read_suggests_for_large_file(tmp_path: Path) -> None:
+    target = tmp_path / "large.txt"
+    target.write_text("\n".join(str(i) for i in range(500)))
+    msg = check_context_optimization.check_read({"file_path": str(target)}, _settings())
+    assert "[Context Optimization]" in msg
+    assert "offset/limit" in msg
+    assert "500 行" in msg
+
+
+def test_check_read_skipped_when_file_too_large(tmp_path: Path) -> None:
+    target = tmp_path / "huge.txt"
+    target.write_text("\n".join(str(i) for i in range(500)))
+    msg = check_context_optimization.check_read(
+        {"file_path": str(target)},
+        _settings(max_file_size_bytes=10),
+    )
+    assert msg == ""
+
+
+def test_check_read_skipped_for_non_regular_file(tmp_path: Path) -> None:
+    import os
+
+    fifo = tmp_path / "fifo"
+    try:
+        os.mkfifo(fifo)
+    except (AttributeError, OSError):
+        return
+    msg = check_context_optimization.check_read({"file_path": str(fifo)}, _settings())
+    assert msg == ""
+
+
+# ---------------------------------------------------------------------------
+# check_grep
+# ---------------------------------------------------------------------------
+
+
+def test_check_grep_skipped_for_files_with_matches() -> None:
+    msg = check_context_optimization.check_grep(
+        {"output_mode": "files_with_matches", "pattern": "foo"}, _settings()
+    )
+    assert msg == ""
+
+
+def test_check_grep_skipped_when_head_limit_set() -> None:
+    msg = check_context_optimization.check_grep(
+        {"output_mode": "content", "pattern": "foo", "head_limit": 30}, _settings()
+    )
+    assert msg == ""
+
+
+def test_check_grep_suggests_for_unbounded_content_mode() -> None:
+    msg = check_context_optimization.check_grep(
+        {"output_mode": "content", "pattern": "foo"}, _settings()
+    )
+    assert "[Context Optimization]" in msg
+    assert "head_limit" in msg
+    assert "count" in msg
+
+
+def test_check_grep_truncates_long_pattern() -> None:
+    long_pattern = "x" * 200
+    msg = check_context_optimization.check_grep(
+        {"output_mode": "content", "pattern": long_pattern}, _settings()
+    )
+    assert "..." in msg
+    assert long_pattern not in msg
+
+
+# ---------------------------------------------------------------------------
+# check_bash
+# ---------------------------------------------------------------------------
+
+
+def test_check_bash_suggests_read_for_cat() -> None:
+    msg = check_context_optimization.check_bash({"command": "cat src/foo.py"}, _settings())
+    assert "Read" in msg
+    assert "cat" in msg
+
+
+def test_check_bash_suggests_glob_for_find() -> None:
+    msg = check_context_optimization.check_bash({"command": "find . -name '*.py'"}, _settings())
+    assert "Glob" in msg
+
+
+def test_check_bash_suggests_grep_for_rg() -> None:
+    msg = check_context_optimization.check_bash({"command": "rg --files src/"}, _settings())
+    assert "Grep" in msg
+
+
+def test_check_bash_handles_sudo_prefix() -> None:
+    msg = check_context_optimization.check_bash({"command": "sudo cat /etc/hosts"}, _settings())
+    assert "Read" in msg
+
+
+def test_check_bash_returns_empty_for_unknown_command() -> None:
+    msg = check_context_optimization.check_bash({"command": "git status"}, _settings())
+    assert msg == ""
+
+
+def test_check_bash_returns_empty_for_invalid_shell_syntax() -> None:
+    msg = check_context_optimization.check_bash({"command": "cat 'unterminated"}, _settings())
+    assert msg == ""
+
+
+def test_check_bash_returns_empty_for_blank_command() -> None:
+    msg = check_context_optimization.check_bash({"command": ""}, _settings())
+    assert msg == ""
+
+
+# ---------------------------------------------------------------------------
+# _sanitize_for_message
+# ---------------------------------------------------------------------------
+
+
+def test_sanitize_strips_control_characters() -> None:
+    result = check_context_optimization._sanitize_for_message("foo\nbar\rbaz\x00qux")
+    assert "\n" not in result
+    assert "\r" not in result
+    assert "\x00" not in result
+    assert "foo" in result and "qux" in result
+
+
+def test_sanitize_truncates_long_strings() -> None:
+    result = check_context_optimization._sanitize_for_message("x" * 500, max_len=20)
+    assert len(result) == 20
+    assert result.endswith("...")
+
+
+def test_check_grep_sanitizes_pattern_with_newline() -> None:
+    msg = check_context_optimization.check_grep(
+        {"output_mode": "content", "pattern": "foo\nbar"},
+        _settings(),
+    )
+    pattern_line_count = sum(1 for line in msg.split("\n") if "pattern:" in line)
+    assert pattern_line_count == 1
+    assert "foo bar" in msg or "'foo bar'" in msg

--- a/packages/quality-gates/tests/test_check_context_optimization.py
+++ b/packages/quality-gates/tests/test_check_context_optimization.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import os
 from pathlib import Path
+
+import pytest
 
 from tests.module_loader import load_module
 
@@ -86,13 +89,11 @@ def test_check_read_skipped_when_file_too_large(tmp_path: Path) -> None:
 
 
 def test_check_read_skipped_for_non_regular_file(tmp_path: Path) -> None:
-    import os
-
     fifo = tmp_path / "fifo"
     try:
         os.mkfifo(fifo)
-    except (AttributeError, OSError):
-        return
+    except (AttributeError, OSError) as exc:
+        pytest.skip(f"mkfifo not supported on this platform: {exc}")
     msg = check_context_optimization.check_read({"file_path": str(fifo)}, _settings())
     assert msg == ""
 
@@ -158,6 +159,18 @@ def test_check_bash_suggests_grep_for_rg() -> None:
 def test_check_bash_handles_sudo_prefix() -> None:
     msg = check_context_optimization.check_bash({"command": "sudo cat /etc/hosts"}, _settings())
     assert "Read" in msg
+
+
+def test_check_bash_handles_chained_wrapper_prefixes() -> None:
+    msg = check_context_optimization.check_bash(
+        {"command": "sudo nice cat /etc/hosts"}, _settings()
+    )
+    assert "Read" in msg
+
+
+def test_check_bash_returns_empty_when_only_wrappers() -> None:
+    msg = check_context_optimization.check_bash({"command": "sudo nice"}, _settings())
+    assert msg == ""
 
 
 def test_check_bash_returns_empty_for_unknown_command() -> None:


### PR DESCRIPTION
Closes #10

## Summary

- PreToolUse(Read|Grep|Bash) で非効率なツール使用を検出し、エスカレーション戦略への切り替えを提案する Hook を `quality-gates` パッケージに追加
  - **Read**: 200 行超ファイルの全文読み込み → `offset/limit` 部分読み込みを提案
  - **Grep**: `output_mode=content` + `head_limit` 未指定 → `count` モード経由を提案
  - **Bash**: `cat`/`head`/`tail`/`find`/`grep`/`rg` の単純呼び出し → 専用ツール (Read/Glob/Grep) を提案
- `audit-flags.json` に `features.context_optimization` 機能フラグを追加（閾値・無効化対応）
- `_sanitize_for_message` でメッセージ埋め込み前に改行・制御文字を除去
- `_count_lines` は `stat.S_ISREG` で通常ファイル限定（FIFO/特殊ファイルを除外）
- `/review` High 指摘 3 件を修正:
  - `manifest.json` の `depends` に `"audit"` 追加（クロスパッケージ依存の明示化）
  - `os.path.isfile` と `_count_lines` の二重 stat 解消
  - `sudo`/`time`/`nice` ラッパー検出を while ループで連鎖対応

## Testing

- [x] テスト実施済み
  - `pytest -q`: 1180 passed, 17 skipped
  - `ruff check .`: All checks passed
  - `ruff format --check .`: 132 files already formatted
  - 新規テスト 25 件（正常系・異常系・境界値・sanitize・FIFO・連鎖ラッパー）

## Release Note

- ユーザー向け変更点: なし（開発者向け Hook）
- `CHANGELOG.md` 更新: 済み（Unreleased > Added に追記）

## Checklist

- [x] PR タイトルが GitHub Release にそのまま載っても読める
- [x] 適切なラベルを付けた (`enhancement`)
- [x] `CHANGELOG.md` の `Unreleased` を更新した