### PR TITLE
chore: add gtr post-create setup hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,9 +64,51 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
-### Changed
+- `release-readiness` を強化し、`pyright` を導入。あわせて release workflow を追加 (#26)
 
 ### Fixed
 
-<!-- release 時は Unreleased の内容を次のような version セクションへ確定する -->
-<!-- ## [0.1.0] - YYYY-MM-DD -->
+- `inject-shared-context` の hook 出力フォーマットを修正 (#27)
+
+## [0.2.2] - 2026-03-22
+
+### Added
+
+- `review` のレビュー自動修正ループ機能を追加 (#21)
+- facet composition に Knowledge 層と Scripts を導入 (#24)
+
+### Changed
+
+- manifest-SSOT アーキテクチャへの移行に伴い、`packages/skills` を廃止 (#22)
+- `packages/rules` を廃止し、facet build へ完全委譲する構成に整理 (#25)
+
+## [0.2.1] - 2026-03-22
+
+### Added
+
+- ファセットシステムを導入し、E2E テストを追加 (#19)
+
+### Changed
+
+- モジュール分割を進め、ドキュメント体系を整理 (#19)
+
+## [0.2.0] - 2026-03-14
+
+### Added
+
+- コンテキスト共有基盤と指示書テンプレート管理を導入 (#17)
+
+### Changed
+
+- `design-tracker` の運用乖離と migration guide の記載不整合を整理 (#16)
+
+## [0.1.0] - 2026-03-06
+
+### Added
+
+- AI Orchestra の初期リリース
+- Claude Code + Codex CLI + Gemini CLI のエージェントルーティング
+- `Plans.md` による SSOT タスク管理
+- PyPI パッケージ `orchex` として公開
+- hook による自動品質ゲート
+

--- a/scripts/gtr-post-create.sh
+++ b/scripts/gtr-post-create.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# gtr postCreate hook for ai-orchestra repository
+# 環境変数: REPO_ROOT, WORKTREE_PATH, BRANCH (git-worktree-runner が渡す)
+
+if [[ -z "${REPO_ROOT:-}" || -z "${WORKTREE_PATH:-}" ]]; then
+  echo "[gtr-post-create] ERROR: REPO_ROOT or WORKTREE_PATH not set" >&2
+  exit 1
+fi
+
+TARGET_SETTINGS="$WORKTREE_PATH/.claude/settings.local.json"
+SOURCE_ORCHESTRA_JSON="$REPO_ROOT/.claude/orchestra.json"
+ORCHESTRA_MANAGER="$REPO_ROOT/scripts/orchestra-manager.py"
+
+if [[ -f "$TARGET_SETTINGS" ]]; then
+  echo "[gtr-post-create] AI Orchestra already initialized, skipping"
+  exit 0
+fi
+
+if [[ ! -f "$SOURCE_ORCHESTRA_JSON" ]]; then
+  echo "[gtr-post-create] WARN: $SOURCE_ORCHESTRA_JSON not found, skipping"
+  exit 0
+fi
+
+if [[ ! -f "$ORCHESTRA_MANAGER" ]]; then
+  echo "[gtr-post-create] ERROR: $ORCHESTRA_MANAGER not found" >&2
+  exit 1
+fi
+
+declare -a PACKAGES=()
+while IFS= read -r line; do
+  [[ -z "$line" ]] && continue
+  PACKAGES+=("$line")
+done < <(
+  python3 - "$SOURCE_ORCHESTRA_JSON" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+data = json.loads(path.read_text(encoding="utf-8"))
+
+for pkg in data.get("installed_packages") or []:
+    if pkg:
+        print(pkg)
+PY
+)
+
+if [[ "${#PACKAGES[@]}" -eq 0 ]]; then
+  echo "[gtr-post-create] WARN: installed_packages not found, skipping"
+  exit 0
+fi
+
+echo "[gtr-post-create] Setting up AI Orchestra..."
+AI_ORCHESTRA_DIR="$REPO_ROOT" \
+  python3 "$ORCHESTRA_MANAGER" install "${PACKAGES[@]}" --project "$WORKTREE_PATH"
+echo "[gtr-post-create] Done${BRANCH:+ (branch: $BRANCH)}"


### PR DESCRIPTION
## Summary

- `scripts/gtr-post-create.sh` を追加し、このリポジトリの `git-worktree-runner` `postCreate` hook で AI Orchestra の再セットアップを自動化
- `REPO_ROOT/.claude/orchestra.json` の `installed_packages` を読み取り、新しい worktree に対して `scripts/orchestra-manager.py install ... --project "$WORKTREE_PATH"` を実行
- 対象 worktree に `.claude/settings.local.json` が既にある場合はスキップ

## Testing

- [x] `bash -n scripts/gtr-post-create.sh`
- [x] 一時ディレクトリと fake `orchestra-manager.py` を使った手動ドライラン

## Release Note

- ユーザー向け変更点: なし（開発用 worktree hook のみ）
- `CHANGELOG.md` 更新: 不要

## Checklist

- [x] PR タイトルが GitHub Release にそのまま載っても読める
- [x] 適切なラベルを付けた (`task`)
- [x] ユーザー向け変更がないため `CHANGELOG.md` 更新は不要


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * ワークツリーの自動セットアップスクリプトを追加しました。新しいワークツリー作成時に環境変数の検証、設定ファイルの確認、パッケージの自動インストールが実行されるようになります。開発環境のセットアップが効率化されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->