### PR TITLE
chore(release): v0.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.2.6] - 2026-04-13
+
 ### Added
 
 - `audit/scripts/dashboard-html.py`: 既存ログを横断集計し Chart.js で可視化する HTML ダッシュボード生成スクリプトを追加 (#31)


### PR DESCRIPTION
## Summary
- CHANGELOG.md を v0.2.6 用に更新

このPRは `task release` により自動作成されました。