### PR TITLE
feat: ダッシュボード UX 改善・ヘルプ強化・worktree ログ集約

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- `audit/scripts/dashboard-html.py`: `-o` 未指定時のデフォルト出力先を `.claude/YYYYMMDD-dashboard.html` に変更。`-o -` で stdout 出力をサポート
+- `orchex scripts`: スクリプト一覧に説明（description）カラムと使い方ヒントを追加
+- `packages/audit/manifest.json`: scripts エントリを `{path, description}` オブジェクト形式に拡張（文字列形式との後方互換あり）
+
+### Added
+
+- `scripts/lib/orchestra_models.py`: `ScriptEntry` データクラスを追加（manifest の scripts 値を型安全に扱う）
+- `packages/audit/README.md`: audit パッケージの使い方ドキュメントを追加
+
+### Fixed
+
+- `audit/hooks/event_logger.py`: worktree 環境でログが分散する問題を修正。全 worktree のログを root worktree の `.claude/logs/audit/` に集約するようにした
+
 ## [0.2.6] - 2026-04-13
 
 ### Added

--- a/packages/audit/README.md
+++ b/packages/audit/README.md
@@ -1,0 +1,181 @@
+# audit パッケージ
+
+AI Orchestra の統合イベントログ・監査基盤。Claude Code セッション中のルーティング、CLI 呼び出し、サブエージェント実行を JSONL 形式で記録し、ダッシュボードや KPI レポートで可視化します。
+
+## 概要
+
+- セッション単位でイベントを `.claude/logs/audit/` に蓄積
+- フックが自動でイベントを記録（設定不要）
+- テキスト・HTML のダッシュボードでセッションを横断分析
+- KPI スコアカードで品質傾向を把握
+
+## クイックスタート
+
+```bash
+# 利用可能なスクリプトの確認
+orchex scripts --package audit
+
+# テキストダッシュボード（ターミナル表示）
+orchex run audit dashboard
+
+# HTML ダッシュボード（.claude/YYYYMMDD-dashboard.html に自動保存）
+orchex run audit dashboard-html
+
+# ログビューア（最新イベントを表示）
+orchex run audit log-viewer
+
+# KPI レポート（直近 7 日間）
+orchex run audit kpi-report
+```
+
+## スクリプト詳細
+
+### dashboard — テキストダッシュボード
+
+ターミナル上でセッション統計をテキスト形式で表示します。
+
+```bash
+orchex run audit dashboard
+```
+
+### dashboard-html — HTML ダッシュボード
+
+Chart.js グラフ付きの HTML レポートを生成します。デフォルトでは `.claude/YYYYMMDD-dashboard.html` に自動保存されます。
+
+```bash
+# 自動保存（.claude/YYYYMMDD-dashboard.html）
+orchex run audit dashboard-html
+
+# 特定セッションのみ表示
+orchex run audit dashboard-html -- --session <SESSION_ID>
+
+# 保存先を指定
+orchex run audit dashboard-html -- -o custom-path.html
+
+# 標準出力に出力（パイプ利用時）
+orchex run audit dashboard-html -- -o -
+```
+
+| オプション       | 説明                                |
+| ---------------- | ----------------------------------- |
+| `--session <ID>` | 表示対象のセッション ID を絞り込む  |
+| `-o <PATH>`      | 出力先ファイルパス（`-` で stdout） |
+
+### log-viewer — 監査ログビューア
+
+イベントの検索・フィルタリング・トレース追跡を行います。
+
+```bash
+# 最新ログを表示
+orchex run audit log-viewer
+
+# セッション絞り込み
+orchex run audit log-viewer -- --session <SESSION_ID>
+
+# イベント種別で絞り込み
+orchex run audit log-viewer -- --type <EVENT_TYPE>
+
+# トレース ID で追跡
+orchex run audit log-viewer -- --trace <TRACE_ID>
+
+# 表示件数を指定（デフォルト: 20）
+orchex run audit log-viewer -- --limit 50
+
+# JSONL 生ログ形式で出力
+orchex run audit log-viewer -- --raw
+```
+
+| オプション       | 説明                                              |
+| ---------------- | ------------------------------------------------- |
+| `--session <ID>` | セッション ID でフィルタ                          |
+| `--type <TYPE>`  | イベント種別でフィルタ（例: `route`, `cli_call`） |
+| `--trace <ID>`   | トレース ID でイベント連鎖を追跡                  |
+| `--limit <N>`    | 表示件数の上限（デフォルト: 20）                  |
+| `--raw`          | JSONL 形式のまま出力                              |
+
+### kpi-report — KPI スコアカードレポート
+
+ルーティング精度・品質ゲート通過率などの KPI を集計します。
+
+```bash
+# 直近 7 日間（デフォルト）
+orchex run audit kpi-report
+
+# 集計期間を指定（日数）
+orchex run audit kpi-report -- --days 7
+
+# ファイルに保存
+orchex run audit kpi-report -- --output report.txt
+```
+
+| オプション        | 説明                            |
+| ----------------- | ------------------------------- |
+| `--days <N>`      | 集計対象の日数（デフォルト: 7） |
+| `--output <PATH>` | レポートの保存先ファイルパス    |
+
+### analyze-cli-usage — CLI 利用パターン分析
+
+Codex CLI・Gemini CLI の呼び出し頻度・パターンを分析します。
+
+```bash
+# 直近 30 日間（デフォルト）
+orchex run audit analyze-cli-usage
+
+# 集計期間を指定
+orchex run audit analyze-cli-usage -- --days 30
+```
+
+| オプション   | 説明                             |
+| ------------ | -------------------------------- |
+| `--days <N>` | 集計対象の日数（デフォルト: 30） |
+
+## フック一覧
+
+パッケージインストール後、以下のフックが自動で有効になります。
+
+| フック                         | タイミング          | 記録内容                                            |
+| ------------------------------ | ------------------- | --------------------------------------------------- |
+| `audit-bootstrap.py`           | SessionStart        | セッション開始・メタ情報（セッション ID、開始時刻） |
+| `audit-session-end.py`         | SessionEnd          | セッション終了・サマリー統計                        |
+| `audit-prompt.py`              | UserPromptSubmit    | ユーザープロンプトの受信イベント                    |
+| `audit-route.py`               | PostToolUse         | エージェントルーティング結果                        |
+| `audit-cli.py`                 | PostToolUse（Bash） | CLI ツール（Codex/Gemini）の呼び出し記録            |
+| `audit-subagent-start.py`      | SubagentStart       | サブエージェントの起動                              |
+| `audit-subagent-end.py`        | SubagentStop        | サブエージェントの終了・結果                        |
+| `audit-instructions-loaded.py` | InstructionsLoaded  | 指示書の読み込み完了                                |
+
+ログは `.claude/logs/audit/` 配下に JSONL 形式で保存されます。
+
+## 設定
+
+設定ファイルは `.claude/config/audit/` に配置されます。
+
+### audit-flags.json — 機能フラグ
+
+| フラグ                                     | デフォルト | 説明                                  |
+| ------------------------------------------ | ---------- | ------------------------------------- |
+| `route_audit.enabled`                      | `true`     | ルーティング記録の有効/無効           |
+| `route_audit.max_excerpt_chars`            | `160`      | プロンプト抜粋の最大文字数            |
+| `quality_gate.enabled`                     | `true`     | 品質ゲートチェックの有効/無効         |
+| `quality_gate.block_on_failed_test`        | `false`    | テスト失敗時にブロックするか          |
+| `kpi_scorecard.enabled`                    | `true`     | KPI スコアカード集計の有効/無効       |
+| `kpi_scorecard.default_period_days`        | `7`        | KPI 集計のデフォルト期間（日）        |
+| `context_optimization.enabled`             | `true`     | コンテキスト最適化チェックの有効/無効 |
+| `context_optimization.read_line_threshold` | `200`      | 警告を出すファイル読み込み行数の閾値  |
+
+### delegation-policy.json — ルーティングポリシー
+
+キーワードベースのエージェントルーティングルールを定義します。`default_route` でフォールバック先を指定し、`rules` でキーワード→エージェントのマッピングを追加できます。
+
+プロジェクト固有の上書きは `.claude/config/audit/audit-flags.local.json` で行います（`config-loading` ルール準拠）。
+
+```json
+// .claude/config/audit/audit-flags.local.json
+{
+  "features": {
+    "quality_gate": {
+      "block_on_failed_test": true
+    }
+  }
+}
+```

--- a/packages/audit/hooks/event_logger.py
+++ b/packages/audit/hooks/event_logger.py
@@ -18,12 +18,15 @@ import uuid
 from typing import Any
 
 
-def _resolve_root_worktree() -> str | None:
+def _resolve_root_worktree(project_dir: str | None = None) -> str | None:
     """Git の root worktree パスを解決する。
 
     worktree 環境では main worktree のパスを返す。
-    通常リポジトリではリポジトリルートを返す（動作変更なし）。
+    通常リポジトリではリポジトリルートを返す(動作変更なし)。
     git が使えない・結果が不正な場合は None を返す。
+
+    Args:
+        project_dir: git を実行する作業ディレクトリ。省略時は CWD。
     """
     try:
         result = subprocess.run(
@@ -31,6 +34,7 @@ def _resolve_root_worktree() -> str | None:
             capture_output=True,
             text=True,
             timeout=5,
+            cwd=project_dir or None,
         )
         if result.returncode == 0:
             git_common_dir = result.stdout.strip()
@@ -50,10 +54,11 @@ def _resolve_log_root(project_dir: str | None = None) -> str:
     worktree 環境では root worktree に集約する。
     通常環境では _resolve_project_dir と同じ。
     """
-    root = _resolve_root_worktree()
+    resolved = _resolve_project_dir(project_dir)
+    root = _resolve_root_worktree(resolved)
     if root and os.path.isdir(os.path.join(root, ".claude")):
         return root
-    return _resolve_project_dir(project_dir)
+    return resolved
 
 
 # ---------------------------------------------------------------------------

--- a/packages/audit/hooks/event_logger.py
+++ b/packages/audit/hooks/event_logger.py
@@ -12,9 +12,49 @@ import fcntl
 import json
 import os
 import re
+import subprocess
 import tempfile
 import uuid
 from typing import Any
+
+
+def _resolve_root_worktree() -> str | None:
+    """Git の root worktree パスを解決する。
+
+    worktree 環境では main worktree のパスを返す。
+    通常リポジトリではリポジトリルートを返す（動作変更なし）。
+    git が使えない・結果が不正な場合は None を返す。
+    """
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--path-format=absolute", "--git-common-dir"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode == 0:
+            git_common_dir = result.stdout.strip()
+            if not git_common_dir:
+                return None
+            root = os.path.dirname(git_common_dir)
+            if os.path.isabs(root) and os.path.isdir(root):
+                return root
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        pass
+    return None
+
+
+def _resolve_log_root(project_dir: str | None = None) -> str:
+    """ログ保存先のルートを解決する。
+
+    worktree 環境では root worktree に集約する。
+    通常環境では _resolve_project_dir と同じ。
+    """
+    root = _resolve_root_worktree()
+    if root and os.path.isdir(os.path.join(root, ".claude")):
+        return root
+    return _resolve_project_dir(project_dir)
+
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -127,7 +167,7 @@ def get_session_log_path(session_id: str, project_dir: str | None = None) -> str
     Returns:
         セッションログファイルの絶対パス。
     """
-    root = _resolve_project_dir(project_dir)
+    root = _resolve_log_root(project_dir)
     safe_id = _sanitize_session_id(session_id)
     return os.path.join(root, SESSIONS_DIR, f"{safe_id}.jsonl")
 
@@ -141,7 +181,7 @@ def get_log_base_path(project_dir: str | None = None) -> str:
     Returns:
         `.claude/logs/audit` の絶対パス。
     """
-    root = _resolve_project_dir(project_dir)
+    root = _resolve_log_root(project_dir)
     return os.path.join(root, LOG_BASE_DIR)
 
 
@@ -398,7 +438,7 @@ def init_session_dir(session_id: str, project_dir: str | None = None) -> str:
     Returns:
         セッションログファイルの絶対パス。
     """
-    root = _resolve_project_dir(project_dir)
+    root = _resolve_log_root(project_dir)
     sessions_path = os.path.join(root, SESSIONS_DIR)
     os.makedirs(sessions_path, mode=LOG_DIR_MODE, exist_ok=True)
     try:
@@ -426,7 +466,7 @@ def iter_session_events(
     Returns:
         v1 スキーマのイベントレコード一覧（時刻順）
     """
-    root = _resolve_project_dir(project_dir)
+    root = _resolve_log_root(project_dir)
     sessions_path = os.path.join(root, SESSIONS_DIR)
     if not os.path.isdir(sessions_path):
         return []
@@ -470,7 +510,7 @@ def list_sessions(project_dir: str | None = None) -> list[str]:
     Returns:
         セッション ID 文字列のリスト。ディレクトリが存在しなければ空リスト。
     """
-    root = _resolve_project_dir(project_dir)
+    root = _resolve_log_root(project_dir)
     sessions_path = os.path.join(root, SESSIONS_DIR)
     if not os.path.isdir(sessions_path):
         return []

--- a/packages/audit/manifest.json
+++ b/packages/audit/manifest.json
@@ -31,11 +31,26 @@
   "agents": [],
   "rules": [],
   "scripts": [
-    "scripts/dashboard.py",
-    "scripts/dashboard-html.py",
-    "scripts/log-viewer.py",
-    "scripts/kpi-report.py",
-    "scripts/analyze-cli-usage.py"
+    {
+      "path": "scripts/dashboard.py",
+      "description": "テキスト形式の監査ダッシュボード"
+    },
+    {
+      "path": "scripts/dashboard-html.py",
+      "description": "HTML 形式の監査ダッシュボード（Chart.js グラフ付き）"
+    },
+    {
+      "path": "scripts/log-viewer.py",
+      "description": "監査ログビューア（イベント検索・トレース追跡）"
+    },
+    {
+      "path": "scripts/kpi-report.py",
+      "description": "KPI スコアカードレポート"
+    },
+    {
+      "path": "scripts/analyze-cli-usage.py",
+      "description": "CLI 利用パターン分析"
+    }
   ],
   "config": ["config/delegation-policy.json", "config/audit-flags.json"]
 }

--- a/packages/audit/scripts/dashboard-html.py
+++ b/packages/audit/scripts/dashboard-html.py
@@ -438,7 +438,11 @@ def main() -> int:
         "Data tables are always visible offline.",
     )
     parser.add_argument("--session", help="Filter by session ID")
-    parser.add_argument("-o", "--output", help="Output file path (default: stdout)")
+    parser.add_argument(
+        "-o",
+        "--output",
+        help="Output file path (default: .claude/YYYYMMDD-dashboard.html, use '-' for stdout)",
+    )
     parser.add_argument("--project", help="Project directory override")
     parser.add_argument("--title", default="AI Orchestra Dashboard", help="Dashboard title")
     args = parser.parse_args()
@@ -453,14 +457,20 @@ def main() -> int:
 
     html_content = generate_html(events, title=args.title, session_id=args.session)
 
-    if args.output:
-        out_path = os.path.abspath(args.output)
+    if args.output == "-":
+        print(html_content)
+    else:
+        if args.output:
+            out_path = os.path.abspath(args.output)
+        else:
+            base_dir = project_dir or "."
+            claude_dir = os.path.join(base_dir, ".claude")
+            date_str = datetime.now(UTC).strftime("%Y%m%d")
+            out_path = os.path.abspath(os.path.join(claude_dir, f"{date_str}-dashboard.html"))
         os.makedirs(os.path.dirname(out_path), exist_ok=True)
         with open(out_path, "w", encoding="utf-8") as f:
             f.write(html_content)
         print(f"Dashboard written to {out_path}", file=sys.stderr)
-    else:
-        print(html_content)
 
     return 0
 

--- a/scripts/lib/orchestra_models.py
+++ b/scripts/lib/orchestra_models.py
@@ -29,6 +29,27 @@ class HookEntry:
 
 
 @dataclass
+class ScriptEntry:
+    """スクリプトエントリ（manifest.json の scripts 値）"""
+
+    path: str
+    description: str = ""
+
+    @classmethod
+    def from_json(cls, value: str | dict[str, Any]) -> ScriptEntry:
+        """JSON 値から ScriptEntry を生成。文字列または辞書に対応。"""
+        if isinstance(value, str):
+            return cls(path=value)
+        if "path" not in value:
+            msg = f"ScriptEntry requires 'path' key, got: {value!r}"
+            raise ValueError(msg)
+        return cls(
+            path=value["path"],
+            description=value.get("description", ""),
+        )
+
+
+@dataclass
 class Package:
     """パッケージ情報"""
 
@@ -38,7 +59,7 @@ class Package:
     depends: list[str]
     hooks: dict[str, list[HookEntry]]
     files: list[str]
-    scripts: list[str]
+    scripts: list[ScriptEntry]
     config: list[str]
     skills: list[str]
     agents: list[str]
@@ -63,7 +84,7 @@ class Package:
             depends=data.get("depends", []),
             hooks=hooks,
             files=data.get("files", []),
-            scripts=data.get("scripts", []),
+            scripts=[ScriptEntry.from_json(s) for s in data.get("scripts", [])],
             config=data.get("config", []),
             skills=data.get("skills", []),
             agents=data.get("agents", []),

--- a/scripts/lib/orchestra_models.py
+++ b/scripts/lib/orchestra_models.py
@@ -40,11 +40,12 @@ class ScriptEntry:
         """JSON 値から ScriptEntry を生成。文字列または辞書に対応。"""
         if isinstance(value, str):
             return cls(path=value)
-        if "path" not in value:
-            msg = f"ScriptEntry requires 'path' key, got: {value!r}"
+        path = value.get("path")
+        if not isinstance(path, str) or not path.strip():
+            msg = f"ScriptEntry requires non-empty 'path' string, got: {value!r}"
             raise ValueError(msg)
         return cls(
-            path=value["path"],
+            path=path,
             description=value.get("description", ""),
         )
 

--- a/scripts/orchestra-manager.py
+++ b/scripts/orchestra-manager.py
@@ -682,12 +682,12 @@ class OrchestraManager(ContextMixin, HooksMixin):
         フルパス（例: scripts/dashboard.py）のいずれも受け付ける。
         """
         for entry in pkg.scripts:
-            entry_path = Path(entry)
+            entry_path = Path(entry.path)
             stem = entry_path.stem
 
-            if script_name in (entry, entry_path.name, stem):
+            if script_name in (entry.path, entry_path.name, stem):
                 if entry_path.parts[0] == "scripts":
-                    return pkg.path / entry
+                    return pkg.path / entry.path
                 return pkg.path / "scripts" / entry_path.name
         return None
 
@@ -714,7 +714,7 @@ class OrchestraManager(ContextMixin, HooksMixin):
 
         script_path = self.resolve_script_path(pkg, script_name)
         if script_path is None:
-            available = [Path(s).stem for s in pkg.scripts]
+            available = [Path(s.path).stem for s in pkg.scripts]
             print(
                 f"エラー: スクリプト '{script_name}' が見つかりません\n"
                 f"利用可能: {', '.join(available)}",
@@ -753,21 +753,20 @@ class OrchestraManager(ContextMixin, HooksMixin):
         for name in sorted(target_packages.keys()):
             pkg = target_packages[name]
             for entry in pkg.scripts:
-                entry_path = Path(entry)
+                entry_path = Path(entry.path)
                 short_name = entry_path.stem
-                if entry_path.parts[0] == "scripts":
-                    display_path = entry
-                else:
-                    display_path = f"scripts/{entry_path.name}"
-                rows.append((name, short_name, display_path))
+                rows.append((name, short_name, entry.description))
 
         if not rows:
             print("スクリプトが見つかりません")
             return
 
-        print(f"{'PACKAGE':<20} {'SCRIPT':<30} {'PATH'}")
-        for pkg_name, short_name, display_path in rows:
-            print(f"{pkg_name:<20} {short_name:<30} {display_path}")
+        print(f"{'PACKAGE':<20} {'SCRIPT':<25} {'DESCRIPTION'}")
+        for pkg_name, short_name, desc in rows:
+            print(f"{pkg_name:<20} {short_name:<25} {desc}")
+
+        print("\n実行方法: orchex run <package> <script> [-- <args>]")
+        print("詳細:     orchex run <package> <script> -- --help")
 
     def list_presets(self) -> None:
         """プリセット一覧を表示"""

--- a/tests/unit/test_dashboard_html_output.py
+++ b/tests/unit/test_dashboard_html_output.py
@@ -1,0 +1,84 @@
+"""dashboard-html.py の出力パス生成テスト。"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+
+
+class TestDashboardHtmlDefaultOutput:
+    SCRIPT = "packages/audit/scripts/dashboard-html.py"
+
+    def test_default_output_writes_to_claude_dir(self, tmp_path: Path) -> None:
+        """-o 未指定時に .claude/YYYYMMDD-dashboard.html へ保存される。"""
+        # Arrange
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        (project_dir / ".claude").mkdir()
+        date_str = datetime.now(UTC).strftime("%Y%m%d")
+        expected = project_dir / ".claude" / f"{date_str}-dashboard.html"
+
+        # Act
+        result = subprocess.run(
+            [sys.executable, self.SCRIPT, "--project", str(project_dir)],
+            capture_output=True,
+            text=True,
+        )
+
+        # Assert
+        assert result.returncode == 0
+        assert expected.exists()
+        assert "Dashboard written to" in result.stderr
+
+    def test_explicit_output_path(self, tmp_path: Path) -> None:
+        """-o 指定時にそのパスへ保存される。"""
+        # Arrange
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        out_file = tmp_path / "custom.html"
+
+        # Act
+        result = subprocess.run(
+            [
+                sys.executable,
+                self.SCRIPT,
+                "--project",
+                str(project_dir),
+                "-o",
+                str(out_file),
+            ],
+            capture_output=True,
+            text=True,
+        )
+
+        # Assert
+        assert result.returncode == 0
+        assert out_file.exists()
+        assert "Dashboard written to" in result.stderr
+
+    def test_stdout_output_with_dash(self, tmp_path: Path) -> None:
+        """-o - 指定時に stdout へ出力される。"""
+        # Arrange
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+
+        # Act
+        result = subprocess.run(
+            [
+                sys.executable,
+                self.SCRIPT,
+                "--project",
+                str(project_dir),
+                "-o",
+                "-",
+            ],
+            capture_output=True,
+            text=True,
+        )
+
+        # Assert
+        assert result.returncode == 0
+        assert "<!DOCTYPE html>" in result.stdout
+        assert "Dashboard written to" not in result.stderr

--- a/tests/unit/test_dashboard_html_output.py
+++ b/tests/unit/test_dashboard_html_output.py
@@ -17,8 +17,7 @@ class TestDashboardHtmlDefaultOutput:
         project_dir = tmp_path / "project"
         project_dir.mkdir()
         (project_dir / ".claude").mkdir()
-        date_str = datetime.now(UTC).strftime("%Y%m%d")
-        expected = project_dir / ".claude" / f"{date_str}-dashboard.html"
+        before = datetime.now(UTC).strftime("%Y%m%d")
 
         # Act
         result = subprocess.run(
@@ -26,10 +25,15 @@ class TestDashboardHtmlDefaultOutput:
             capture_output=True,
             text=True,
         )
+        after = datetime.now(UTC).strftime("%Y%m%d")
 
         # Assert
         assert result.returncode == 0
-        assert expected.exists()
+        candidates = {
+            project_dir / ".claude" / f"{before}-dashboard.html",
+            project_dir / ".claude" / f"{after}-dashboard.html",
+        }
+        assert any(p.exists() for p in candidates)
         assert "Dashboard written to" in result.stderr
 
     def test_explicit_output_path(self, tmp_path: Path) -> None:

--- a/tests/unit/test_event_logger_log_root.py
+++ b/tests/unit/test_event_logger_log_root.py
@@ -16,9 +16,6 @@ get_log_base_path = mod.get_log_base_path
 
 
 class TestResolveRootWorktree:
-    def setup_method(self) -> None:
-        pass  # no cache to clear
-
     def test_returns_parent_of_git_common_dir(self, tmp_path: Path) -> None:
         """git rev-parse が成功すると .git の親を返す。"""
         fake_git = tmp_path / "project" / ".git"
@@ -27,8 +24,10 @@ class TestResolveRootWorktree:
         with patch("subprocess.run") as mock_run:
             mock_run.return_value.returncode = 0
             mock_run.return_value.stdout = f"{fake_git}\n"
-            result = _resolve_root_worktree()
+            result = _resolve_root_worktree(str(tmp_path / "project"))
 
+        mock_run.assert_called_once()
+        assert mock_run.call_args.kwargs["cwd"] == str(tmp_path / "project")
         assert result == str(tmp_path / "project")
 
     def test_returns_none_when_git_fails(self) -> None:
@@ -47,19 +46,28 @@ class TestResolveRootWorktree:
 
         assert result is None
 
+    def test_passes_none_cwd_when_no_project_dir(self) -> None:
+        """project_dir 未指定時に cwd=None で git を実行する。"""
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value.returncode = 128
+            mock_run.return_value.stdout = ""
+            _resolve_root_worktree()
+
+        assert mock_run.call_args.kwargs["cwd"] is None
+
 
 class TestResolveLogRoot:
-    def setup_method(self) -> None:
-        pass  # no cache to clear
-
     def test_uses_root_worktree_when_available(self, tmp_path: Path) -> None:
         """root worktree に .claude/ があればそちらを使う。"""
         root = tmp_path / "root"
         root.mkdir()
         (root / ".claude").mkdir()
+        worktree = tmp_path / "worktree"
+        worktree.mkdir()
+        (worktree / ".claude").mkdir()
 
         with patch.object(mod, "_resolve_root_worktree", return_value=str(root)):
-            result = _resolve_log_root("/some/worktree")
+            result = _resolve_log_root(str(worktree))
 
         assert result == str(root)
 
@@ -67,18 +75,25 @@ class TestResolveLogRoot:
         """root worktree に .claude/ がなければフォールバック。"""
         root = tmp_path / "root"
         root.mkdir()
+        worktree = tmp_path / "worktree"
+        worktree.mkdir()
+        (worktree / ".claude").mkdir()
 
         with patch.object(mod, "_resolve_root_worktree", return_value=str(root)):
-            result = _resolve_log_root("/some/worktree")
+            result = _resolve_log_root(str(worktree))
 
-        assert result == "/some/worktree"
+        assert result == str(worktree)
 
-    def test_falls_back_when_git_unavailable(self) -> None:
+    def test_falls_back_when_git_unavailable(self, tmp_path: Path) -> None:
         """git が使えなければ通常の project_dir 解決。"""
-        with patch.object(mod, "_resolve_root_worktree", return_value=None):
-            result = _resolve_log_root("/my/project")
+        project = tmp_path / "project"
+        project.mkdir()
+        (project / ".claude").mkdir()
 
-        assert result == "/my/project"
+        with patch.object(mod, "_resolve_root_worktree", return_value=None):
+            result = _resolve_log_root(str(project))
+
+        assert result == str(project)
 
 
 class TestLogPathsUseLogRoot:

--- a/tests/unit/test_event_logger_log_root.py
+++ b/tests/unit/test_event_logger_log_root.py
@@ -1,0 +1,110 @@
+"""event_logger の _resolve_log_root / _resolve_root_worktree テスト。"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+from tests.module_loader import load_module
+
+mod = load_module("event_logger", "packages/audit/hooks/event_logger.py")
+_resolve_log_root = mod._resolve_log_root
+_resolve_root_worktree = mod._resolve_root_worktree
+get_session_log_path = mod.get_session_log_path
+get_log_base_path = mod.get_log_base_path
+
+
+class TestResolveRootWorktree:
+    def setup_method(self) -> None:
+        pass  # no cache to clear
+
+    def test_returns_parent_of_git_common_dir(self, tmp_path: Path) -> None:
+        """git rev-parse が成功すると .git の親を返す。"""
+        fake_git = tmp_path / "project" / ".git"
+        fake_git.mkdir(parents=True)
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value.returncode = 0
+            mock_run.return_value.stdout = f"{fake_git}\n"
+            result = _resolve_root_worktree()
+
+        assert result == str(tmp_path / "project")
+
+    def test_returns_none_when_git_fails(self) -> None:
+        """git が失敗すると None を返す。"""
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value.returncode = 128
+            mock_run.return_value.stdout = ""
+            result = _resolve_root_worktree()
+
+        assert result is None
+
+    def test_returns_none_when_git_not_found(self) -> None:
+        """git がインストールされていなければ None を返す。"""
+        with patch("subprocess.run", side_effect=FileNotFoundError):
+            result = _resolve_root_worktree()
+
+        assert result is None
+
+
+class TestResolveLogRoot:
+    def setup_method(self) -> None:
+        pass  # no cache to clear
+
+    def test_uses_root_worktree_when_available(self, tmp_path: Path) -> None:
+        """root worktree に .claude/ があればそちらを使う。"""
+        root = tmp_path / "root"
+        root.mkdir()
+        (root / ".claude").mkdir()
+
+        with patch.object(mod, "_resolve_root_worktree", return_value=str(root)):
+            result = _resolve_log_root("/some/worktree")
+
+        assert result == str(root)
+
+    def test_falls_back_when_root_has_no_claude_dir(self, tmp_path: Path) -> None:
+        """root worktree に .claude/ がなければフォールバック。"""
+        root = tmp_path / "root"
+        root.mkdir()
+
+        with patch.object(mod, "_resolve_root_worktree", return_value=str(root)):
+            result = _resolve_log_root("/some/worktree")
+
+        assert result == "/some/worktree"
+
+    def test_falls_back_when_git_unavailable(self) -> None:
+        """git が使えなければ通常の project_dir 解決。"""
+        with patch.object(mod, "_resolve_root_worktree", return_value=None):
+            result = _resolve_log_root("/my/project")
+
+        assert result == "/my/project"
+
+
+class TestLogPathsUseLogRoot:
+    """ログパス関数が _resolve_log_root 経由で root worktree を使うことを検証。"""
+
+    def setup_method(self) -> None:
+        pass  # no cache to clear
+
+    def test_session_log_path_uses_root(self, tmp_path: Path) -> None:
+        root = tmp_path / "root"
+        root.mkdir()
+        (root / ".claude").mkdir()
+
+        with patch.object(mod, "_resolve_root_worktree", return_value=str(root)):
+            path = get_session_log_path("sess-123", "/some/worktree")
+
+        assert str(root) in path
+        assert "sess-123.jsonl" in path
+
+    def test_log_base_path_uses_root(self, tmp_path: Path) -> None:
+        root = tmp_path / "root"
+        root.mkdir()
+        (root / ".claude").mkdir()
+
+        with patch.object(mod, "_resolve_root_worktree", return_value=str(root)):
+            path = get_log_base_path("/some/worktree")
+
+        expected = os.path.join(str(root), ".claude", "logs", "audit")
+        assert path == expected

--- a/tests/unit/test_orchestra_models.py
+++ b/tests/unit/test_orchestra_models.py
@@ -1,14 +1,17 @@
-"""orchestra_models.py の HookEntry / Package テスト。"""
+"""orchestra_models.py の HookEntry / ScriptEntry / Package テスト。"""
 
 from __future__ import annotations
 
 import json
 from pathlib import Path
 
+import pytest
+
 from tests.module_loader import load_module
 
 models_mod = load_module("orchestra_models", "scripts/lib/orchestra_models.py")
 HookEntry = models_mod.HookEntry
+ScriptEntry = models_mod.ScriptEntry
 Package = models_mod.Package
 
 
@@ -43,6 +46,46 @@ class TestHookEntryFromJson:
 
         # Assert
         assert entry.timeout == 5
+
+
+class TestScriptEntryFromJson:
+    def test_string_value_sets_path_only(self) -> None:
+        # Arrange / Act
+        entry = ScriptEntry.from_json("scripts/dashboard.py")
+
+        # Assert
+        assert entry.path == "scripts/dashboard.py"
+        assert entry.description == ""
+
+    def test_dict_value_parses_all_fields(self) -> None:
+        # Arrange
+        value = {"path": "scripts/dashboard.py", "description": "テキストダッシュボード"}
+
+        # Act
+        entry = ScriptEntry.from_json(value)
+
+        # Assert
+        assert entry.path == "scripts/dashboard.py"
+        assert entry.description == "テキストダッシュボード"
+
+    def test_dict_without_description_uses_default(self) -> None:
+        # Arrange
+        value = {"path": "scripts/kpi-report.py"}
+
+        # Act
+        entry = ScriptEntry.from_json(value)
+
+        # Assert
+        assert entry.path == "scripts/kpi-report.py"
+        assert entry.description == ""
+
+    def test_dict_missing_path_raises_value_error(self) -> None:
+        # Arrange
+        value = {"description": "no path key"}
+
+        # Act / Assert
+        with pytest.raises(ValueError, match="requires 'path' key"):
+            ScriptEntry.from_json(value)
 
 
 class TestPackageLoad:
@@ -100,6 +143,38 @@ class TestPackageLoad:
 
         # Assert
         assert pkg.path == pkg_dir
+
+    def test_parses_scripts_as_script_entry_instances(self, tmp_path: Path) -> None:
+        # Arrange
+        manifest_path = tmp_path / "manifest.json"
+        manifest_path.write_text(
+            json.dumps(
+                {
+                    "name": "mypkg",
+                    "version": "1.0.0",
+                    "scripts": [
+                        "scripts/simple.py",
+                        {
+                            "path": "scripts/dashboard.py",
+                            "description": "ダッシュボード",
+                        },
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        # Act
+        pkg = Package.load(manifest_path)
+
+        # Assert
+        assert len(pkg.scripts) == 2
+        assert isinstance(pkg.scripts[0], ScriptEntry)
+        assert isinstance(pkg.scripts[1], ScriptEntry)
+        assert pkg.scripts[0].path == "scripts/simple.py"
+        assert pkg.scripts[0].description == ""
+        assert pkg.scripts[1].path == "scripts/dashboard.py"
+        assert pkg.scripts[1].description == "ダッシュボード"
 
     def test_empty_lists_default_correctly(self, tmp_path: Path) -> None:
         # Arrange

--- a/tests/unit/test_orchestra_models.py
+++ b/tests/unit/test_orchestra_models.py
@@ -84,7 +84,7 @@ class TestScriptEntryFromJson:
         value = {"description": "no path key"}
 
         # Act / Assert
-        with pytest.raises(ValueError, match="requires 'path' key"):
+        with pytest.raises(ValueError, match="non-empty 'path' string"):
             ScriptEntry.from_json(value)
 
 


### PR DESCRIPTION
## Summary

- `dashboard-html` のデフォルト出力先を `.claude/YYYYMMDD-dashboard.html` に変更（`-o` 不要に）
- `orchex scripts` に description カラムと使い方ヒントを追加
- worktree 環境のログを root worktree に集約（ログ消失問題の修正）
- audit パッケージ README を追加
- manifest.json の scripts エントリを `{path, description}` 形式に拡張（後方互換あり）

## Changed files

| ファイル | 変更内容 |
|---------|---------|
| `packages/audit/scripts/dashboard-html.py` | デフォルト出力先変更、`-o -` で stdout |
| `packages/audit/hooks/event_logger.py` | `_resolve_root_worktree()` / `_resolve_log_root()` 追加 |
| `packages/audit/manifest.json` | scripts を `{path, description}` 形式に拡張 |
| `scripts/lib/orchestra_models.py` | `ScriptEntry` データクラス追加 |
| `scripts/orchestra-manager.py` | `list_scripts` に description 表示 |
| `packages/audit/README.md` | 新規: audit パッケージ使い方ドキュメント |
| `CHANGELOG.md` | `[Unreleased]` に変更内容を追記 |
| `tests/unit/test_orchestra_models.py` | ScriptEntry テスト追加 |
| `tests/unit/test_dashboard_html_output.py` | 新規: 出力パステスト |
| `tests/unit/test_event_logger_log_root.py` | 新規: worktree ログ集約テスト |

## Test plan

- [x] `pytest tests/ -q` — 838 passed, 17 skipped
- [x] `orchex scripts` — description カラム表示確認
- [x] `dashboard-html` デフォルト出力 → `.claude/20260413-dashboard.html`
- [x] `dashboard-html -o -` → stdout 出力
- [x] `/review` — code-reviewer + security-reviewer（Critical 0, High 3 → 修正済み）
- [x] `/release-readiness` — PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ダッシュボードHTMLはデフォルトで`.claude`ディレクトリに日付付きで保存されるようになりました
  * スクリプトリストで説明文が表示されるようになりました
  * Gitワークツリーの自動検出に対応しました

* **改善**
  * スクリプト一覧の表示がシンプルになりました

* **テスト**
  * ダッシュボード出力と監査ログ機能のテストが追加されました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->