### PR TITLE
feat: staging ワークフロー基盤の整備

### DIFF
--- a/.claude/orchestra.json
+++ b/.claude/orchestra.json
@@ -1,5 +1,4 @@
 {
-  "orchestra_dir": "/Users/yoshihiko/ghq/github.com/yoshihiko555/ai-orchestra",
   "installed_packages": [
     "agent-routing",
     "audit",
@@ -47,5 +46,5 @@
     "config/core/task-memory.yaml",
     "config/git-workflow/sandbox-requirements.json"
   ],
-  "last_sync": "2026-04-11T07:26:22.086365+00:00"
+  "last_sync": "2026-04-13T11:06:51.110164+00:00"
 }

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -2,7 +2,7 @@ name: Python CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, staging]
   pull_request:
 
 jobs:

--- a/scripts/lib/settings_io.py
+++ b/scripts/lib/settings_io.py
@@ -32,12 +32,12 @@ def load_orchestra_json(project_dir: Path) -> dict[str, Any]:
     """orchestra.json をロードする。"""
     path = project_dir / ".claude" / "orchestra.json"
     if not path.exists():
-        return {"installed_packages": [], "orchestra_dir": "", "last_sync": ""}
+        return {"installed_packages": [], "last_sync": ""}
     try:
         with open(path, encoding="utf-8") as f:
             return json.load(f)
     except (json.JSONDecodeError, OSError):
-        return {"installed_packages": [], "orchestra_dir": "", "last_sync": ""}
+        return {"installed_packages": [], "last_sync": ""}
 
 
 def save_orchestra_json(project_dir: Path, data: dict[str, Any]) -> None:

--- a/scripts/orchestra-manager.py
+++ b/scripts/orchestra-manager.py
@@ -291,12 +291,12 @@ class OrchestraManager(ContextMixin, HooksMixin):
         """初回同期を実行（sync-orchestra.py と同等のロジック）"""
         orch = self.load_orchestra_json(project_dir)
         installed = orch.get("installed_packages", [])
-        orchestra_dir = orch.get("orchestra_dir", "")
+        orchestra_dir = os.environ.get("AI_ORCHESTRA_DIR", "")
 
         if not orchestra_dir:
             return
 
-        orchestra_path = Path(orchestra_dir)
+        orchestra_path = Path(orchestra_dir).resolve()
         if not orchestra_path.is_dir():
             return
 
@@ -477,7 +477,6 @@ class OrchestraManager(ContextMixin, HooksMixin):
             if pkg.name not in installed_packages:
                 installed_packages.add(pkg.name)
             orch["installed_packages"] = sorted(installed_packages)
-            orch["orchestra_dir"] = str(self.orchestra_dir)
             orch["last_sync"] = datetime.datetime.now(datetime.UTC).isoformat()
             self.save_orchestra_json(project_dir, orch)
 
@@ -623,8 +622,6 @@ class OrchestraManager(ContextMixin, HooksMixin):
                 continue
             self._install_context_init_files(pkg, project_dir, dry_run)
 
-        if not orch.get("orchestra_dir"):
-            orch["orchestra_dir"] = str(self.orchestra_dir)
         orch.setdefault("installed_packages", [])
         if dry_run:
             print("[DRY-RUN] orchestra.json 初期化")

--- a/scripts/sync-orchestra.py
+++ b/scripts/sync-orchestra.py
@@ -18,6 +18,7 @@ Note: skills/rules は facet build に完全委譲（packages からは同期し
 
 import datetime
 import json
+import os
 import sys
 from pathlib import Path
 
@@ -48,8 +49,6 @@ def read_hook_input() -> dict:
 
 def get_project_dir(data: dict) -> str:
     """hook 入力からプロジェクトディレクトリを取得"""
-    import os
-
     cwd = data.get("cwd") or ""
     if cwd:
         return cwd
@@ -72,12 +71,12 @@ def main() -> None:
         return
 
     installed_packages = orch.get("installed_packages", [])
-    orchestra_dir = orch.get("orchestra_dir", "")
+    orchestra_dir = os.environ.get("AI_ORCHESTRA_DIR", "")
 
     if not orchestra_dir:
         return
 
-    orchestra_path = Path(orchestra_dir)
+    orchestra_path = Path(orchestra_dir).resolve()
     if not orchestra_path.is_dir():
         return
 

--- a/tests/unit/test_settings_io.py
+++ b/tests/unit/test_settings_io.py
@@ -89,14 +89,14 @@ class TestLoadOrchestraJson:
     def test_file_not_found(self, tmp_path):
         """ファイルが存在しない場合、デフォルト値を返す。"""
         result = settings_io.load_orchestra_json(tmp_path)
-        assert result == {"installed_packages": [], "orchestra_dir": "", "last_sync": ""}
+        assert result == {"installed_packages": [], "last_sync": ""}
 
     def test_valid_json(self, tmp_path):
         """正常な JSON を読み込める。"""
         claude_dir = tmp_path / ".claude"
         claude_dir.mkdir()
         path = claude_dir / "orchestra.json"
-        data = {"installed_packages": ["core"], "orchestra_dir": "/tmp", "last_sync": "2026-01-01"}
+        data = {"installed_packages": ["core"], "last_sync": "2026-01-01"}
         path.write_text(json.dumps(data), encoding="utf-8")
 
         result = settings_io.load_orchestra_json(tmp_path)
@@ -110,7 +110,7 @@ class TestLoadOrchestraJson:
         path.write_text("not json", encoding="utf-8")
 
         result = settings_io.load_orchestra_json(tmp_path)
-        assert result == {"installed_packages": [], "orchestra_dir": "", "last_sync": ""}
+        assert result == {"installed_packages": [], "last_sync": ""}
 
 
 class TestSaveOrchestraJson:
@@ -118,7 +118,7 @@ class TestSaveOrchestraJson:
 
     def test_creates_and_writes(self, tmp_path):
         """ファイルを作成して書き込む。"""
-        data = {"installed_packages": ["core", "agent-routing"], "orchestra_dir": "/home/test"}
+        data = {"installed_packages": ["core", "agent-routing"]}
         settings_io.save_orchestra_json(tmp_path, data)
 
         path = tmp_path / ".claude" / "orchestra.json"


### PR DESCRIPTION
## Summary

- `orchestra.json` の `orchestra_dir` フィールドを廃止し、環境変数 `AI_ORCHESTRA_DIR` に一本化
- パストラバーサル対策として `Path.resolve()` を追加
- CI（`python-ci.yml`）の push トリガーに `staging` ブランチを追加

## Testing

- [x] テスト実施済み（1238 passed, 17 skipped）
- [x] `/review` 実施済み（Critical 0, High 2 件修正済み）

## Release Note

- ユーザー向け変更点: なし（内部リファクタ）
- `CHANGELOG.md` 更新: 不要

## Checklist

- [x] PR タイトルが GitHub Release にそのまま載っても読める
- [x] 適切なラベルを付けた
- [x] ユーザー向け変更がないため CHANGELOG 更新不要

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * オーケストラディレクトリの設定方式を環境変数ベースに変更しました。設定ファイルへの保存を廃止し、システム環境変数から取得するようになります。
  * パス解決処理を改善しました。

* **Tests**
  * 設定ファイルのテストケースを更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->