### PR TITLE
feat: PR base branch resolver を追加

### DIFF
--- a/.claude/skills/issue-fix/SKILL.md
+++ b/.claude/skills/issue-fix/SKILL.md
@@ -122,10 +122,53 @@ PR 本文は以下のテンプレート構造に従う。プロジェクトに `
 
 ## Git 操作ルール
 
-- `main` への直接 push は行わない
+- `main` / 解決済み base branch への直接 push は行わない
 - マージ方式は GitHub 上の **Squash and merge** を前提とする
-- 競合解決は PR ブランチ側で `origin/main` を取り込んで行う
+- 競合解決は PR ブランチ側で `origin/{base}` を取り込んで行う（`{base}` は後述の resolver で解決）
 - Push は `-u` フラグでトラッキングを設定する: `git push -u origin {ブランチ名}`
+
+## Base Branch Resolution
+
+**PR の base branch を固定せず、resolver スクリプトで解決する。** `pr-create` / `issue-fix` / その他 PR を作成するスキルは、このルールに従って `$BASE` を取得する。
+
+### Resolver スクリプト
+
+```bash
+: "${AI_ORCHESTRA_DIR:?AI_ORCHESTRA_DIR is not set}"
+BASE=$(python3 "$AI_ORCHESTRA_DIR/packages/git-workflow/scripts/resolve_base_branch.py" \
+  ${BASE_OVERRIDE:+--base "$BASE_OVERRIDE"})
+```
+
+- 実体: `packages/git-workflow/scripts/resolve_base_branch.py`
+- 出力: stdout に解決済み base branch 名を 1 行（`origin/` プレフィックスは除去される）
+- `AI_ORCHESTRA_DIR` 未設定時はガードで即座に失敗させ、`$BASE` が空のまま `gh pr create --base ""` が実行される事故を防ぐ
+- `BASE_OVERRIDE` が未定義の場合 `${BASE_OVERRIDE:+...}` は空に展開され、`--base` 引数なしで resolver を呼ぶ
+
+### 解決優先順位
+
+1. **`--base <branch>` 明示指定** — ユーザーが `/pr-create --base stage` のように指定した値
+2. **環境変数 `AI_ORCHESTRA_BASE_BRANCH`** — プロジェクト固有のデフォルト（shell 設定や `.envrc` 等で設定）
+3. **自動推定** — 候補 `main` / `master` / `staging` / `stage` / `develop` の中で実在するものを対象に、各候補について `merge-base <candidate> HEAD` → `rev-list --count <merge-base>..<candidate>` を計算し、距離が最小のもの（≒ 最も近い親ブランチ）を選ぶ。remote を優先し、remote になければローカルブランチを見る
+4. **Fallback: `main`** — 候補が 1 つも存在しない場合
+
+### スキル側の使い方
+
+- Usage に `--base <branch>` 引数を追加する（明示指定を受け付ける）
+- Context 収集の冒頭で resolver を呼び `$BASE` に格納する
+- 差分収集 (`git log`, `git diff`) / プレビュー / `gh pr create` のすべてで `$BASE` を使う
+- 「ベースブランチ: main」のような固定表記はしない（`ベースブランチ: $BASE` と表現する）
+
+### 検証手順
+
+| 運用パターン                                          | 期待動作                                |
+| ----------------------------------------------------- | --------------------------------------- |
+| `main` only のリポジトリ                              | `$BASE = main`                          |
+| `main` + `stage` で `stage` から切った feature branch | `$BASE = stage`                         |
+| `main` + `stage` で `main` から切った feature branch  | `$BASE = main`                          |
+| `--base release` を明示指定                           | `$BASE = release`（他条件を無視）       |
+| `AI_ORCHESTRA_BASE_BRANCH=develop`                    | `$BASE = develop`（明示指定がなければ） |
+
+自動テストは `tests/unit/test_resolve_base_branch.py` が担保する。
 
 ---
 
@@ -236,24 +279,29 @@ Issue の内容から関連するコードを Grep/Glob で調査する:
 ## Issue #{番号}: {タイトル}
 
 ### 要約
+
 {Issue の内容を 1-2 文で要約}
 
 ### 変更予定ファイル
+
 - `path/to/file1.ts` — {変更内容}
 - `path/to/file2.ts` — {変更内容}
 
 ### 実装手順
+
 1. {ステップ 1}
 2. {ステップ 2}
 3. {ステップ 3}
 
 ### リスク・注意点
+
 - {潜在的な問題と対策}
 ```
 
 #### 1-4. ユーザー承認
 
 AskUserQuestion で計画の承認を求める:
+
 - 「計画通り進める」
 - 「計画を修正する」
 - 「中止する」
@@ -268,12 +316,12 @@ AskUserQuestion で計画の承認を求める:
 
 Issue のラベルからブランチプレフィックスを決定する:
 
-| ラベル | プレフィックス | 例 |
-|--------|-------------|-----|
-| bug | `fix/` | `fix/issue-42-login-error` |
-| feature | `feat/` | `feat/issue-42-dark-mode` |
-| task | `chore/` | `chore/issue-42-ci-setup` |
-| その他 | `fix/` | `fix/issue-42-slug` |
+| ラベル  | プレフィックス | 例                         |
+| ------- | -------------- | -------------------------- |
+| bug     | `fix/`         | `fix/issue-42-login-error` |
+| feature | `feat/`        | `feat/issue-42-dark-mode`  |
+| task    | `chore/`       | `chore/issue-42-ci-setup`  |
+| その他  | `fix/`         | `fix/issue-42-slug`        |
 
 ```bash
 git checkout -b {prefix}issue-{番号}-{slug}
@@ -350,6 +398,7 @@ git diff --stat
 `git diff --stat` の出力からファイルパス一覧を取得し、`skill-review-policy.md` のパスパターンマッピングに基づいてレビュアーを選定する（最大 2 個）。
 
 **選定手順:**
+
 1. 変更ファイルのパスをパスパターンマッピングに照合
 2. 優先順位（security > code > performance > ux）に基づき最大 2 レビュアーに絞る
 3. コード変更がある限り最低 `code-reviewer` は選定する
@@ -396,6 +445,7 @@ Closes #{番号}"
 ```
 
 プレフィックスは Issue のラベルに応じて決定する:
+
 - bug → `fix:`
 - feature → `feat:`
 - task → `chore:`
@@ -412,15 +462,20 @@ AskUserQuestion で次のアクションを選択:
 
 PR Standards Policy に従い、以下を実行する:
 
-1. PR テンプレートを取得する（`.github/PULL_REQUEST_TEMPLATE.md` → フォールバック）
-2. ブランチプレフィックスからタイトルプレフィックスとラベルを決定する
-3. テンプレートの各セクションを埋める（レビュー結果がある場合は Summary に追記）
-4. `Closes #{番号}` を本文冒頭に追加する
-5. Push して PR を作成する:
+1. PR Standards Policy の "Base Branch Resolution" に従い `$BASE` を解決する（issue-fix では `--base` 引数は持たず、環境変数 `AI_ORCHESTRA_BASE_BRANCH` → 自動推定 → fallback の順で解決される）:
+   ```bash
+   : "${AI_ORCHESTRA_DIR:?AI_ORCHESTRA_DIR is not set}"
+   BASE=$(python3 "$AI_ORCHESTRA_DIR/packages/git-workflow/scripts/resolve_base_branch.py")
+   ```
+2. PR テンプレートを取得する（`.github/PULL_REQUEST_TEMPLATE.md` → フォールバック）
+3. ブランチプレフィックスからタイトルプレフィックスとラベルを決定する
+4. テンプレートの各セクションを埋める（レビュー結果がある場合は Summary に追記）
+5. `Closes #{番号}` を本文冒頭に追加する
+6. Push して PR を作成する:
 
 ```bash
 git push -u origin {ブランチ名}
-gh pr create --title "{prefix}: {要約}" --label "{ラベル}" --body "{生成された本文}"
+gh pr create --title "{prefix}: {要約}" --label "{ラベル}" --base "$BASE" --body "{生成された本文}"
 ```
 
 ## 注意事項

--- a/.claude/skills/issue-fix/SKILL.md
+++ b/.claude/skills/issue-fix/SKILL.md
@@ -148,7 +148,7 @@ BASE=$(python3 "$AI_ORCHESTRA_DIR/packages/git-workflow/scripts/resolve_base_bra
 
 1. **`--base <branch>` 明示指定** — ユーザーが `/pr-create --base stage` のように指定した値
 2. **環境変数 `AI_ORCHESTRA_BASE_BRANCH`** — プロジェクト固有のデフォルト（shell 設定や `.envrc` 等で設定）
-3. **自動推定** — 候補 `main` / `master` / `staging` / `stage` / `develop` の中で実在するものを対象に、各候補について `merge-base <candidate> HEAD` → `rev-list --count <merge-base>..<candidate>` を計算し、距離が最小のもの（≒ 最も近い親ブランチ）を選ぶ。remote を優先し、remote になければローカルブランチを見る
+3. **自動推定** — 候補 `staging` / `stage` / `develop` / `main` / `master` の中で実在するものを対象に、各候補について `merge-base <candidate> HEAD` → `rev-list --count <merge-base>..<candidate>` を計算し、距離が最小のもの（≒ 最も近い親ブランチ）を選ぶ。remote を優先し、remote になければローカルブランチを見る。同距離の場合は **候補リストの先頭優先** で、多段ブランチ運用（`main` + `stage` 等）で両者が同一コミットを指すときは `stage` 系を選ぶ
 4. **Fallback: `main`** — 候補が 1 つも存在しない場合
 
 ### スキル側の使い方
@@ -160,13 +160,14 @@ BASE=$(python3 "$AI_ORCHESTRA_DIR/packages/git-workflow/scripts/resolve_base_bra
 
 ### 検証手順
 
-| 運用パターン                                          | 期待動作                                |
-| ----------------------------------------------------- | --------------------------------------- |
-| `main` only のリポジトリ                              | `$BASE = main`                          |
-| `main` + `stage` で `stage` から切った feature branch | `$BASE = stage`                         |
-| `main` + `stage` で `main` から切った feature branch  | `$BASE = main`                          |
-| `--base release` を明示指定                           | `$BASE = release`（他条件を無視）       |
-| `AI_ORCHESTRA_BASE_BRANCH=develop`                    | `$BASE = develop`（明示指定がなければ） |
+| 運用パターン                                                     | 期待動作                                |
+| ---------------------------------------------------------------- | --------------------------------------- |
+| `main` only のリポジトリ                                         | `$BASE = main`                          |
+| `main` + `stage` で `stage` から切った feature branch            | `$BASE = stage`                         |
+| `main` + `stage` で `main` から切った feature branch (divergent) | `$BASE = main`                          |
+| `main` + `stage` が同一コミットを指す状態 (tie-break)            | `$BASE = stage`（候補リストの先頭優先） |
+| `--base release` を明示指定                                      | `$BASE = release`（他条件を無視）       |
+| `AI_ORCHESTRA_BASE_BRANCH=develop`                               | `$BASE = develop`（明示指定がなければ） |
 
 自動テストは `tests/unit/test_resolve_base_branch.py` が担保する。
 

--- a/.claude/skills/pr-create/SKILL.md
+++ b/.claude/skills/pr-create/SKILL.md
@@ -191,7 +191,7 @@ BASE=$(python3 "$AI_ORCHESTRA_DIR/packages/git-workflow/scripts/resolve_base_bra
 
 1. **`--base <branch>` 明示指定** — ユーザーが `/pr-create --base stage` のように指定した値
 2. **環境変数 `AI_ORCHESTRA_BASE_BRANCH`** — プロジェクト固有のデフォルト（shell 設定や `.envrc` 等で設定）
-3. **自動推定** — 候補 `main` / `master` / `staging` / `stage` / `develop` の中で実在するものを対象に、各候補について `merge-base <candidate> HEAD` → `rev-list --count <merge-base>..<candidate>` を計算し、距離が最小のもの（≒ 最も近い親ブランチ）を選ぶ。remote を優先し、remote になければローカルブランチを見る
+3. **自動推定** — 候補 `staging` / `stage` / `develop` / `main` / `master` の中で実在するものを対象に、各候補について `merge-base <candidate> HEAD` → `rev-list --count <merge-base>..<candidate>` を計算し、距離が最小のもの（≒ 最も近い親ブランチ）を選ぶ。remote を優先し、remote になければローカルブランチを見る。同距離の場合は **候補リストの先頭優先** で、多段ブランチ運用（`main` + `stage` 等）で両者が同一コミットを指すときは `stage` 系を選ぶ
 4. **Fallback: `main`** — 候補が 1 つも存在しない場合
 
 ### スキル側の使い方
@@ -203,13 +203,14 @@ BASE=$(python3 "$AI_ORCHESTRA_DIR/packages/git-workflow/scripts/resolve_base_bra
 
 ### 検証手順
 
-| 運用パターン                                          | 期待動作                                |
-| ----------------------------------------------------- | --------------------------------------- |
-| `main` only のリポジトリ                              | `$BASE = main`                          |
-| `main` + `stage` で `stage` から切った feature branch | `$BASE = stage`                         |
-| `main` + `stage` で `main` から切った feature branch  | `$BASE = main`                          |
-| `--base release` を明示指定                           | `$BASE = release`（他条件を無視）       |
-| `AI_ORCHESTRA_BASE_BRANCH=develop`                    | `$BASE = develop`（明示指定がなければ） |
+| 運用パターン                                                     | 期待動作                                |
+| ---------------------------------------------------------------- | --------------------------------------- |
+| `main` only のリポジトリ                                         | `$BASE = main`                          |
+| `main` + `stage` で `stage` から切った feature branch            | `$BASE = stage`                         |
+| `main` + `stage` で `main` から切った feature branch (divergent) | `$BASE = main`                          |
+| `main` + `stage` が同一コミットを指す状態 (tie-break)            | `$BASE = stage`（候補リストの先頭優先） |
+| `--base release` を明示指定                                      | `$BASE = release`（他条件を無視）       |
+| `AI_ORCHESTRA_BASE_BRANCH=develop`                               | `$BASE = develop`（明示指定がなければ） |
 
 自動テストは `tests/unit/test_resolve_base_branch.py` が担保する。
 

--- a/.claude/skills/pr-create/SKILL.md
+++ b/.claude/skills/pr-create/SKILL.md
@@ -165,10 +165,53 @@ PR 本文は以下のテンプレート構造に従う。プロジェクトに `
 
 ## Git 操作ルール
 
-- `main` への直接 push は行わない
+- `main` / 解決済み base branch への直接 push は行わない
 - マージ方式は GitHub 上の **Squash and merge** を前提とする
-- 競合解決は PR ブランチ側で `origin/main` を取り込んで行う
+- 競合解決は PR ブランチ側で `origin/{base}` を取り込んで行う（`{base}` は後述の resolver で解決）
 - Push は `-u` フラグでトラッキングを設定する: `git push -u origin {ブランチ名}`
+
+## Base Branch Resolution
+
+**PR の base branch を固定せず、resolver スクリプトで解決する。** `pr-create` / `issue-fix` / その他 PR を作成するスキルは、このルールに従って `$BASE` を取得する。
+
+### Resolver スクリプト
+
+```bash
+: "${AI_ORCHESTRA_DIR:?AI_ORCHESTRA_DIR is not set}"
+BASE=$(python3 "$AI_ORCHESTRA_DIR/packages/git-workflow/scripts/resolve_base_branch.py" \
+  ${BASE_OVERRIDE:+--base "$BASE_OVERRIDE"})
+```
+
+- 実体: `packages/git-workflow/scripts/resolve_base_branch.py`
+- 出力: stdout に解決済み base branch 名を 1 行（`origin/` プレフィックスは除去される）
+- `AI_ORCHESTRA_DIR` 未設定時はガードで即座に失敗させ、`$BASE` が空のまま `gh pr create --base ""` が実行される事故を防ぐ
+- `BASE_OVERRIDE` が未定義の場合 `${BASE_OVERRIDE:+...}` は空に展開され、`--base` 引数なしで resolver を呼ぶ
+
+### 解決優先順位
+
+1. **`--base <branch>` 明示指定** — ユーザーが `/pr-create --base stage` のように指定した値
+2. **環境変数 `AI_ORCHESTRA_BASE_BRANCH`** — プロジェクト固有のデフォルト（shell 設定や `.envrc` 等で設定）
+3. **自動推定** — 候補 `main` / `master` / `staging` / `stage` / `develop` の中で実在するものを対象に、各候補について `merge-base <candidate> HEAD` → `rev-list --count <merge-base>..<candidate>` を計算し、距離が最小のもの（≒ 最も近い親ブランチ）を選ぶ。remote を優先し、remote になければローカルブランチを見る
+4. **Fallback: `main`** — 候補が 1 つも存在しない場合
+
+### スキル側の使い方
+
+- Usage に `--base <branch>` 引数を追加する（明示指定を受け付ける）
+- Context 収集の冒頭で resolver を呼び `$BASE` に格納する
+- 差分収集 (`git log`, `git diff`) / プレビュー / `gh pr create` のすべてで `$BASE` を使う
+- 「ベースブランチ: main」のような固定表記はしない（`ベースブランチ: $BASE` と表現する）
+
+### 検証手順
+
+| 運用パターン                                          | 期待動作                                |
+| ----------------------------------------------------- | --------------------------------------- |
+| `main` only のリポジトリ                              | `$BASE = main`                          |
+| `main` + `stage` で `stage` から切った feature branch | `$BASE = stage`                         |
+| `main` + `stage` で `main` から切った feature branch  | `$BASE = main`                          |
+| `--base release` を明示指定                           | `$BASE = release`（他条件を無視）       |
+| `AI_ORCHESTRA_BASE_BRANCH=develop`                    | `$BASE = develop`（明示指定がなければ） |
+
+自動テストは `tests/unit/test_resolve_base_branch.py` が担保する。
 
 ---
 
@@ -181,20 +224,31 @@ PR 本文は以下のテンプレート構造に従う。プロジェクトに `
 ```
 /pr-create
 /pr-create --issue 42
+/pr-create --base stage
 /pr-create --issue 42 --reviewers "code-reviewer: LGTM"
 ```
+
+- `--base <branch>` は base branch を明示指定する（省略時は resolver で解決）
 
 ## Context 収集
 
 スキル実行時に以下の情報を収集する:
 
 ```bash
+# base branch の解決（PR Standards Policy の "Base Branch Resolution" 参照）
+: "${AI_ORCHESTRA_DIR:?AI_ORCHESTRA_DIR is not set}"
+BASE=$(python3 "$AI_ORCHESTRA_DIR/packages/git-workflow/scripts/resolve_base_branch.py" \
+  ${BASE_OVERRIDE:+--base "$BASE_OVERRIDE"})
+
 # ブランチ・ステータス・ベースブランチとの差分
 git branch --show-current
 git status --short
-git log --oneline main..HEAD
-git diff --stat main..HEAD
+git log --oneline "$BASE..HEAD"
+git diff --stat "$BASE..HEAD"
 ```
+
+- `--base` 引数があれば `BASE_OVERRIDE` に代入してから resolver を呼ぶ
+- 以降の手順で PR タイトル生成・差分収集・`gh pr create` のすべてに `$BASE` を使う
 
 ## Workflow
 
@@ -206,13 +260,13 @@ git diff --stat main..HEAD
 BRANCH=$(git branch --show-current)
 ```
 
-`main` ブランチ上にいる場合はエラーで終了する（PR 作成対象のブランチに移動するよう案内）。
+解決済み `$BASE` と `$BRANCH` が一致する場合（= base branch 上で実行された場合）はエラーで終了する（PR 作成対象のブランチに移動するよう案内）。
 
 #### 1-2. コミット履歴の取得
 
 ```bash
-git log --oneline main..HEAD
-git diff --stat main..HEAD
+git log --oneline "$BASE..HEAD"
+git diff --stat "$BASE..HEAD"
 ```
 
 コミットが 0 件の場合はエラーで終了する。
@@ -226,6 +280,7 @@ gh pr list --head {ブランチ名} --state open --json number,title,url
 ```
 
 既存 PR がある場合は AskUserQuestion で対応を選択する:
+
 - **既存 PR を開く** — URL を報告して終了
 - **新規 PR を作成** — 新しい PR を作成する
 
@@ -285,7 +340,7 @@ PR Standards Policy の「ブランチプレフィックスとラベルの対応
 ```
 PR タイトル: {タイトル}
 ラベル: {ラベル}
-ベースブランチ: main
+ベースブランチ: {$BASE}
 
 --- PR 本文プレビュー ---
 {生成された本文}
@@ -295,6 +350,7 @@ PR タイトル: {タイトル}
 ```
 
 選択肢:
+
 - **作成する** — そのまま PR を作成
 - **タイトルを修正** — タイトルのみ変更
 - **本文を修正** — 本文を変更
@@ -318,6 +374,7 @@ git push -u origin {ブランチ名}
 gh pr create \
   --title "{タイトル}" \
   --label "{ラベル}" \
+  --base "$BASE" \
   --body "$(cat <<'EOF'
 {生成された本文}
 EOF
@@ -331,13 +388,13 @@ PR を作成しました:
 - URL: {PR URL}
 - タイトル: {タイトル}
 - ラベル: {ラベル}
-- ベースブランチ: main
+- ベースブランチ: {$BASE}
 ```
 
 ## 注意事項
 
 - `gh` コマンドは認証済みであることを前提とする
-- `main` への直接 push は行わない
+- 解決済み base branch への直接 push は行わない
 - マージ方式は GitHub 上の Squash and merge を前提とする
 - ユーザー向け変更がある場合は `CHANGELOG.md` の `Unreleased` 更新を Checklist で確認する
 - PR タイトルは GitHub Release にそのまま載ることを想定し、簡潔かつ明確にする

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - `scripts/lib/orchestra_models.py`: `ScriptEntry` データクラスを追加（manifest の scripts 値を型安全に扱う）
 - `packages/audit/README.md`: audit パッケージの使い方ドキュメントを追加
-- `packages/git-workflow/scripts/resolve_base_branch.py`: PR の base branch を `--base` 明示指定 > 環境変数 `AI_ORCHESTRA_BASE_BRANCH` > merge-base 自動推定 > fallback (`main`) の優先順で解決する CLI を追加。`main` + `stage` 等の多段ブランチ運用に対応 (#63)
+- `packages/git-workflow/scripts/resolve_base_branch.py`: PR の base branch を `--base` 明示指定 > 環境変数 `AI_ORCHESTRA_BASE_BRANCH` > merge-base 自動推定 > fallback (`main`) の優先順で解決する CLI を追加。`main` + `stage` 等の多段ブランチ運用に対応。候補が同距離の場合は `staging` / `stage` 系を `main` / `master` より優先する (#63)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - `scripts/lib/orchestra_models.py`: `ScriptEntry` データクラスを追加（manifest の scripts 値を型安全に扱う）
 - `packages/audit/README.md`: audit パッケージの使い方ドキュメントを追加
+- `packages/git-workflow/scripts/resolve_base_branch.py`: PR の base branch を `--base` 明示指定 > 環境変数 `AI_ORCHESTRA_BASE_BRANCH` > merge-base 自動推定 > fallback (`main`) の優先順で解決する CLI を追加。`main` + `stage` 等の多段ブランチ運用に対応 (#63)
+
+### Changed
+
+- `pr-create` / `issue-fix` / `pr-standards`: PR 作成時の base branch を `main` 固定から resolver スクリプト経由の解決に切り替え。`/pr-create --base <branch>` で明示指定可能 (#63)
 
 ### Fixed
 

--- a/facets/instructions/issue-fix.md
+++ b/facets/instructions/issue-fix.md
@@ -49,24 +49,29 @@ Issue の内容から関連するコードを Grep/Glob で調査する:
 ## Issue #{番号}: {タイトル}
 
 ### 要約
+
 {Issue の内容を 1-2 文で要約}
 
 ### 変更予定ファイル
+
 - `path/to/file1.ts` — {変更内容}
 - `path/to/file2.ts` — {変更内容}
 
 ### 実装手順
+
 1. {ステップ 1}
 2. {ステップ 2}
 3. {ステップ 3}
 
 ### リスク・注意点
+
 - {潜在的な問題と対策}
 ```
 
 #### 1-4. ユーザー承認
 
 AskUserQuestion で計画の承認を求める:
+
 - 「計画通り進める」
 - 「計画を修正する」
 - 「中止する」
@@ -81,12 +86,12 @@ AskUserQuestion で計画の承認を求める:
 
 Issue のラベルからブランチプレフィックスを決定する:
 
-| ラベル | プレフィックス | 例 |
-|--------|-------------|-----|
-| bug | `fix/` | `fix/issue-42-login-error` |
-| feature | `feat/` | `feat/issue-42-dark-mode` |
-| task | `chore/` | `chore/issue-42-ci-setup` |
-| その他 | `fix/` | `fix/issue-42-slug` |
+| ラベル  | プレフィックス | 例                         |
+| ------- | -------------- | -------------------------- |
+| bug     | `fix/`         | `fix/issue-42-login-error` |
+| feature | `feat/`        | `feat/issue-42-dark-mode`  |
+| task    | `chore/`       | `chore/issue-42-ci-setup`  |
+| その他  | `fix/`         | `fix/issue-42-slug`        |
 
 ```bash
 git checkout -b {prefix}issue-{番号}-{slug}
@@ -163,6 +168,7 @@ git diff --stat
 `git diff --stat` の出力からファイルパス一覧を取得し、`skill-review-policy.md` のパスパターンマッピングに基づいてレビュアーを選定する（最大 2 個）。
 
 **選定手順:**
+
 1. 変更ファイルのパスをパスパターンマッピングに照合
 2. 優先順位（security > code > performance > ux）に基づき最大 2 レビュアーに絞る
 3. コード変更がある限り最低 `code-reviewer` は選定する
@@ -209,6 +215,7 @@ Closes #{番号}"
 ```
 
 プレフィックスは Issue のラベルに応じて決定する:
+
 - bug → `fix:`
 - feature → `feat:`
 - task → `chore:`
@@ -225,15 +232,20 @@ AskUserQuestion で次のアクションを選択:
 
 PR Standards Policy に従い、以下を実行する:
 
-1. PR テンプレートを取得する（`.github/PULL_REQUEST_TEMPLATE.md` → フォールバック）
-2. ブランチプレフィックスからタイトルプレフィックスとラベルを決定する
-3. テンプレートの各セクションを埋める（レビュー結果がある場合は Summary に追記）
-4. `Closes #{番号}` を本文冒頭に追加する
-5. Push して PR を作成する:
+1. PR Standards Policy の "Base Branch Resolution" に従い `$BASE` を解決する（issue-fix では `--base` 引数は持たず、環境変数 `AI_ORCHESTRA_BASE_BRANCH` → 自動推定 → fallback の順で解決される）:
+   ```bash
+   : "${AI_ORCHESTRA_DIR:?AI_ORCHESTRA_DIR is not set}"
+   BASE=$(python3 "$AI_ORCHESTRA_DIR/packages/git-workflow/scripts/resolve_base_branch.py")
+   ```
+2. PR テンプレートを取得する（`.github/PULL_REQUEST_TEMPLATE.md` → フォールバック）
+3. ブランチプレフィックスからタイトルプレフィックスとラベルを決定する
+4. テンプレートの各セクションを埋める（レビュー結果がある場合は Summary に追記）
+5. `Closes #{番号}` を本文冒頭に追加する
+6. Push して PR を作成する:
 
 ```bash
 git push -u origin {ブランチ名}
-gh pr create --title "{prefix}: {要約}" --label "{ラベル}" --body "{生成された本文}"
+gh pr create --title "{prefix}: {要約}" --label "{ラベル}" --base "$BASE" --body "{生成された本文}"
 ```
 
 ## 注意事項

--- a/facets/instructions/pr-create.md
+++ b/facets/instructions/pr-create.md
@@ -7,20 +7,31 @@
 ```
 /pr-create
 /pr-create --issue 42
+/pr-create --base stage
 /pr-create --issue 42 --reviewers "code-reviewer: LGTM"
 ```
+
+- `--base <branch>` は base branch を明示指定する（省略時は resolver で解決）
 
 ## Context 収集
 
 スキル実行時に以下の情報を収集する:
 
 ```bash
+# base branch の解決（PR Standards Policy の "Base Branch Resolution" 参照）
+: "${AI_ORCHESTRA_DIR:?AI_ORCHESTRA_DIR is not set}"
+BASE=$(python3 "$AI_ORCHESTRA_DIR/packages/git-workflow/scripts/resolve_base_branch.py" \
+  ${BASE_OVERRIDE:+--base "$BASE_OVERRIDE"})
+
 # ブランチ・ステータス・ベースブランチとの差分
 git branch --show-current
 git status --short
-git log --oneline main..HEAD
-git diff --stat main..HEAD
+git log --oneline "$BASE..HEAD"
+git diff --stat "$BASE..HEAD"
 ```
+
+- `--base` 引数があれば `BASE_OVERRIDE` に代入してから resolver を呼ぶ
+- 以降の手順で PR タイトル生成・差分収集・`gh pr create` のすべてに `$BASE` を使う
 
 ## Workflow
 
@@ -32,13 +43,13 @@ git diff --stat main..HEAD
 BRANCH=$(git branch --show-current)
 ```
 
-`main` ブランチ上にいる場合はエラーで終了する（PR 作成対象のブランチに移動するよう案内）。
+解決済み `$BASE` と `$BRANCH` が一致する場合（= base branch 上で実行された場合）はエラーで終了する（PR 作成対象のブランチに移動するよう案内）。
 
 #### 1-2. コミット履歴の取得
 
 ```bash
-git log --oneline main..HEAD
-git diff --stat main..HEAD
+git log --oneline "$BASE..HEAD"
+git diff --stat "$BASE..HEAD"
 ```
 
 コミットが 0 件の場合はエラーで終了する。
@@ -52,6 +63,7 @@ gh pr list --head {ブランチ名} --state open --json number,title,url
 ```
 
 既存 PR がある場合は AskUserQuestion で対応を選択する:
+
 - **既存 PR を開く** — URL を報告して終了
 - **新規 PR を作成** — 新しい PR を作成する
 
@@ -111,7 +123,7 @@ PR Standards Policy の「ブランチプレフィックスとラベルの対応
 ```
 PR タイトル: {タイトル}
 ラベル: {ラベル}
-ベースブランチ: main
+ベースブランチ: {$BASE}
 
 --- PR 本文プレビュー ---
 {生成された本文}
@@ -121,6 +133,7 @@ PR タイトル: {タイトル}
 ```
 
 選択肢:
+
 - **作成する** — そのまま PR を作成
 - **タイトルを修正** — タイトルのみ変更
 - **本文を修正** — 本文を変更
@@ -144,6 +157,7 @@ git push -u origin {ブランチ名}
 gh pr create \
   --title "{タイトル}" \
   --label "{ラベル}" \
+  --base "$BASE" \
   --body "$(cat <<'EOF'
 {生成された本文}
 EOF
@@ -157,13 +171,13 @@ PR を作成しました:
 - URL: {PR URL}
 - タイトル: {タイトル}
 - ラベル: {ラベル}
-- ベースブランチ: main
+- ベースブランチ: {$BASE}
 ```
 
 ## 注意事項
 
 - `gh` コマンドは認証済みであることを前提とする
-- `main` への直接 push は行わない
+- 解決済み base branch への直接 push は行わない
 - マージ方式は GitHub 上の Squash and merge を前提とする
 - ユーザー向け変更がある場合は `CHANGELOG.md` の `Unreleased` 更新を Checklist で確認する
 - PR タイトルは GitHub Release にそのまま載ることを想定し、簡潔かつ明確にする

--- a/facets/policies/pr-standards.md
+++ b/facets/policies/pr-standards.md
@@ -70,7 +70,50 @@ PR 本文は以下のテンプレート構造に従う。プロジェクトに `
 
 ## Git 操作ルール
 
-- `main` への直接 push は行わない
+- `main` / 解決済み base branch への直接 push は行わない
 - マージ方式は GitHub 上の **Squash and merge** を前提とする
-- 競合解決は PR ブランチ側で `origin/main` を取り込んで行う
+- 競合解決は PR ブランチ側で `origin/{base}` を取り込んで行う（`{base}` は後述の resolver で解決）
 - Push は `-u` フラグでトラッキングを設定する: `git push -u origin {ブランチ名}`
+
+## Base Branch Resolution
+
+**PR の base branch を固定せず、resolver スクリプトで解決する。** `pr-create` / `issue-fix` / その他 PR を作成するスキルは、このルールに従って `$BASE` を取得する。
+
+### Resolver スクリプト
+
+```bash
+: "${AI_ORCHESTRA_DIR:?AI_ORCHESTRA_DIR is not set}"
+BASE=$(python3 "$AI_ORCHESTRA_DIR/packages/git-workflow/scripts/resolve_base_branch.py" \
+  ${BASE_OVERRIDE:+--base "$BASE_OVERRIDE"})
+```
+
+- 実体: `packages/git-workflow/scripts/resolve_base_branch.py`
+- 出力: stdout に解決済み base branch 名を 1 行（`origin/` プレフィックスは除去される）
+- `AI_ORCHESTRA_DIR` 未設定時はガードで即座に失敗させ、`$BASE` が空のまま `gh pr create --base ""` が実行される事故を防ぐ
+- `BASE_OVERRIDE` が未定義の場合 `${BASE_OVERRIDE:+...}` は空に展開され、`--base` 引数なしで resolver を呼ぶ
+
+### 解決優先順位
+
+1. **`--base <branch>` 明示指定** — ユーザーが `/pr-create --base stage` のように指定した値
+2. **環境変数 `AI_ORCHESTRA_BASE_BRANCH`** — プロジェクト固有のデフォルト（shell 設定や `.envrc` 等で設定）
+3. **自動推定** — 候補 `main` / `master` / `staging` / `stage` / `develop` の中で実在するものを対象に、各候補について `merge-base <candidate> HEAD` → `rev-list --count <merge-base>..<candidate>` を計算し、距離が最小のもの（≒ 最も近い親ブランチ）を選ぶ。remote を優先し、remote になければローカルブランチを見る
+4. **Fallback: `main`** — 候補が 1 つも存在しない場合
+
+### スキル側の使い方
+
+- Usage に `--base <branch>` 引数を追加する（明示指定を受け付ける）
+- Context 収集の冒頭で resolver を呼び `$BASE` に格納する
+- 差分収集 (`git log`, `git diff`) / プレビュー / `gh pr create` のすべてで `$BASE` を使う
+- 「ベースブランチ: main」のような固定表記はしない（`ベースブランチ: $BASE` と表現する）
+
+### 検証手順
+
+| 運用パターン                                          | 期待動作                                |
+| ----------------------------------------------------- | --------------------------------------- |
+| `main` only のリポジトリ                              | `$BASE = main`                          |
+| `main` + `stage` で `stage` から切った feature branch | `$BASE = stage`                         |
+| `main` + `stage` で `main` から切った feature branch  | `$BASE = main`                          |
+| `--base release` を明示指定                           | `$BASE = release`（他条件を無視）       |
+| `AI_ORCHESTRA_BASE_BRANCH=develop`                    | `$BASE = develop`（明示指定がなければ） |
+
+自動テストは `tests/unit/test_resolve_base_branch.py` が担保する。

--- a/facets/policies/pr-standards.md
+++ b/facets/policies/pr-standards.md
@@ -96,7 +96,7 @@ BASE=$(python3 "$AI_ORCHESTRA_DIR/packages/git-workflow/scripts/resolve_base_bra
 
 1. **`--base <branch>` 明示指定** — ユーザーが `/pr-create --base stage` のように指定した値
 2. **環境変数 `AI_ORCHESTRA_BASE_BRANCH`** — プロジェクト固有のデフォルト（shell 設定や `.envrc` 等で設定）
-3. **自動推定** — 候補 `main` / `master` / `staging` / `stage` / `develop` の中で実在するものを対象に、各候補について `merge-base <candidate> HEAD` → `rev-list --count <merge-base>..<candidate>` を計算し、距離が最小のもの（≒ 最も近い親ブランチ）を選ぶ。remote を優先し、remote になければローカルブランチを見る
+3. **自動推定** — 候補 `staging` / `stage` / `develop` / `main` / `master` の中で実在するものを対象に、各候補について `merge-base <candidate> HEAD` → `rev-list --count <merge-base>..<candidate>` を計算し、距離が最小のもの（≒ 最も近い親ブランチ）を選ぶ。remote を優先し、remote になければローカルブランチを見る。同距離の場合は **候補リストの先頭優先** で、多段ブランチ運用（`main` + `stage` 等）で両者が同一コミットを指すときは `stage` 系を選ぶ
 4. **Fallback: `main`** — 候補が 1 つも存在しない場合
 
 ### スキル側の使い方
@@ -108,12 +108,13 @@ BASE=$(python3 "$AI_ORCHESTRA_DIR/packages/git-workflow/scripts/resolve_base_bra
 
 ### 検証手順
 
-| 運用パターン                                          | 期待動作                                |
-| ----------------------------------------------------- | --------------------------------------- |
-| `main` only のリポジトリ                              | `$BASE = main`                          |
-| `main` + `stage` で `stage` から切った feature branch | `$BASE = stage`                         |
-| `main` + `stage` で `main` から切った feature branch  | `$BASE = main`                          |
-| `--base release` を明示指定                           | `$BASE = release`（他条件を無視）       |
-| `AI_ORCHESTRA_BASE_BRANCH=develop`                    | `$BASE = develop`（明示指定がなければ） |
+| 運用パターン                                                     | 期待動作                                |
+| ---------------------------------------------------------------- | --------------------------------------- |
+| `main` only のリポジトリ                                         | `$BASE = main`                          |
+| `main` + `stage` で `stage` から切った feature branch            | `$BASE = stage`                         |
+| `main` + `stage` で `main` から切った feature branch (divergent) | `$BASE = main`                          |
+| `main` + `stage` が同一コミットを指す状態 (tie-break)            | `$BASE = stage`（候補リストの先頭優先） |
+| `--base release` を明示指定                                      | `$BASE = release`（他条件を無視）       |
+| `AI_ORCHESTRA_BASE_BRANCH=develop`                               | `$BASE = develop`（明示指定がなければ） |
 
 自動テストは `tests/unit/test_resolve_base_branch.py` が担保する。

--- a/packages/git-workflow/manifest.json
+++ b/packages/git-workflow/manifest.json
@@ -8,6 +8,11 @@
   "skills": ["issue-create", "issue-fix", "pr-create"],
   "agents": [],
   "rules": [],
-  "scripts": [],
+  "scripts": [
+    {
+      "path": "scripts/resolve_base_branch.py",
+      "description": "PR の base branch を --base 引数・環境変数・merge-base 自動推定の優先順で解決する"
+    }
+  ],
   "config": ["config/sandbox-requirements.json"]
 }

--- a/packages/git-workflow/scripts/resolve_base_branch.py
+++ b/packages/git-workflow/scripts/resolve_base_branch.py
@@ -75,14 +75,20 @@ def _distance_to_tip(candidate: str, cwd: Path) -> int | None:
 
 
 def _enumerate_refs(cwd: Path, current_branch: str) -> list[str]:
-    """探索対象の ref を集める。remote を優先し、なければローカル。現在ブランチは除外。"""
+    """探索対象の ref を集める。
+
+    - remote ``origin/<name>`` があれば優先。なければローカル ``<name>``。
+    - 現在ブランチと完全一致するローカル ref のみ除外する。
+      ``origin/<name>`` は current_branch と名前が同じでも別 ref なので除外しない
+      （ローカルが remote より遅れている場合でも origin を候補として残すため）。
+    """
     refs: list[str] = []
     for name in CANDIDATES:
-        if name == current_branch:
-            continue
         remote = f"origin/{name}"
         if _ref_exists(remote, cwd):
             refs.append(remote)
+            continue
+        if name == current_branch:
             continue
         if _ref_exists(name, cwd):
             refs.append(name)

--- a/packages/git-workflow/scripts/resolve_base_branch.py
+++ b/packages/git-workflow/scripts/resolve_base_branch.py
@@ -1,0 +1,146 @@
+"""PR の base branch を解決する。
+
+解決優先順位:
+    1. ``--base <branch>`` 明示指定
+    2. 環境変数 ``AI_ORCHESTRA_BASE_BRANCH``
+    3. 自動推定: 候補ブランチのうち現在の HEAD の親に最も近いもの
+    4. Fallback: ``main``
+
+出力は ``origin/`` プレフィックスを剥がした bare branch 名を stdout に一行で返す。
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+ENV_VAR = "AI_ORCHESTRA_BASE_BRANCH"
+CANDIDATES: tuple[str, ...] = ("main", "master", "staging", "stage", "develop")
+FALLBACK = "main"
+
+
+def _run_git(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _ref_exists(ref: str, cwd: Path) -> bool:
+    return _run_git(["rev-parse", "--verify", "--quiet", ref], cwd).returncode == 0
+
+
+def _current_branch(cwd: Path) -> str:
+    result = _run_git(["branch", "--show-current"], cwd)
+    return result.stdout.strip() if result.returncode == 0 else ""
+
+
+def _strip_origin(ref: str) -> str:
+    prefix = "origin/"
+    return ref[len(prefix) :] if ref.startswith(prefix) else ref
+
+
+def _distance_to_tip(candidate: str, cwd: Path) -> int | None:
+    """merge-base(candidate, HEAD) から candidate の tip までのコミット数を返す。
+
+    値が 0 のとき candidate は HEAD の祖先、または HEAD 自身（= 候補は HEAD の親）。
+    値が大きいほど candidate が分岐点から先に進んでおり、親としては遠い。
+    複数候補がある場合は最小値のものを親として選ぶ。
+    同距離の候補が複数ある場合は ``CANDIDATES`` の先頭優先
+    （``main`` > ``master`` > ``staging`` > ``stage`` > ``develop``）。
+    merge-base が取れない場合は None。
+    """
+    mb = _run_git(["merge-base", candidate, "HEAD"], cwd)
+    if mb.returncode != 0 or not mb.stdout.strip():
+        return None
+    base_sha = mb.stdout.strip()
+    count = _run_git(["rev-list", "--count", f"{base_sha}..{candidate}"], cwd)
+    if count.returncode != 0:
+        return None
+    try:
+        return int(count.stdout.strip())
+    except ValueError:
+        return None
+
+
+def _enumerate_refs(cwd: Path, current_branch: str) -> list[str]:
+    """探索対象の ref を集める。remote を優先し、なければローカル。現在ブランチは除外。"""
+    refs: list[str] = []
+    for name in CANDIDATES:
+        if name == current_branch:
+            continue
+        remote = f"origin/{name}"
+        if _ref_exists(remote, cwd):
+            refs.append(remote)
+            continue
+        if _ref_exists(name, cwd):
+            refs.append(name)
+    return refs
+
+
+def _auto_detect(cwd: Path, current_branch: str) -> str | None:
+    refs = _enumerate_refs(cwd, current_branch)
+    best_ref: str | None = None
+    best_dist: int | None = None
+    for ref in refs:
+        dist = _distance_to_tip(ref, cwd)
+        if dist is None:
+            continue
+        if best_dist is None or dist < best_dist:
+            best_ref = ref
+            best_dist = dist
+    return best_ref
+
+
+def resolve(
+    explicit: str | None = None,
+    *,
+    cwd: Path | None = None,
+    env: dict[str, str] | None = None,
+) -> str:
+    cwd = Path(cwd) if cwd else Path.cwd()
+    env = env if env is not None else os.environ
+
+    if explicit:
+        return _strip_origin(explicit.strip())
+
+    env_value = env.get(ENV_VAR, "").strip()
+    if env_value:
+        return _strip_origin(env_value)
+
+    current = _current_branch(cwd)
+    auto = _auto_detect(cwd, current)
+    if auto:
+        return _strip_origin(auto)
+
+    return FALLBACK
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Resolve the PR base branch for the current git repo.",
+    )
+    parser.add_argument(
+        "--base",
+        dest="explicit",
+        default=None,
+        help="Explicit base branch override (highest priority).",
+    )
+    parser.add_argument(
+        "--cwd",
+        default=None,
+        help="Working directory (default: current directory).",
+    )
+    args = parser.parse_args(argv)
+    print(resolve(explicit=args.explicit, cwd=Path(args.cwd) if args.cwd else None))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/git-workflow/scripts/resolve_base_branch.py
+++ b/packages/git-workflow/scripts/resolve_base_branch.py
@@ -18,7 +18,10 @@ import sys
 from pathlib import Path
 
 ENV_VAR = "AI_ORCHESTRA_BASE_BRANCH"
-CANDIDATES: tuple[str, ...] = ("main", "master", "staging", "stage", "develop")
+# 同距離の候補が複数ある場合は先頭が優先される。
+# 多段ブランチ運用（main + stage 等）では feature PR の target を stage 側にしたいため、
+# staging / stage / develop を main / master より先に並べる。
+CANDIDATES: tuple[str, ...] = ("staging", "stage", "develop", "main", "master")
 FALLBACK = "main"
 
 
@@ -53,7 +56,9 @@ def _distance_to_tip(candidate: str, cwd: Path) -> int | None:
     値が大きいほど candidate が分岐点から先に進んでおり、親としては遠い。
     複数候補がある場合は最小値のものを親として選ぶ。
     同距離の候補が複数ある場合は ``CANDIDATES`` の先頭優先
-    （``main`` > ``master`` > ``staging`` > ``stage`` > ``develop``）。
+    （``staging`` > ``stage`` > ``develop`` > ``main`` > ``master``）。
+    多段ブランチ運用で main と stage が同一コミットを指すときに
+    stage 側が選ばれるよう、staging 系が main 系より先になっている。
     merge-base が取れない場合は None。
     """
     mb = _run_git(["merge-base", candidate, "HEAD"], cwd)

--- a/tests/unit/test_resolve_base_branch.py
+++ b/tests/unit/test_resolve_base_branch.py
@@ -55,6 +55,13 @@ def _write_commit(repo: Path, filename: str, content: str, message: str) -> None
     _git(["commit", "-q", "-m", message], repo)
 
 
+@pytest.fixture(autouse=True)
+def _unset_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
+    """実行環境に AI_ORCHESTRA_BASE_BRANCH が設定されていると auto-detect テストが
+    環境変数の値で上書きされるため、毎テスト開始時に必ず削除する。"""
+    monkeypatch.delenv(resolver.ENV_VAR, raising=False)
+
+
 @pytest.fixture()
 def git_repo(tmp_path: Path) -> Path:
     """main ブランチ + 初回コミット済みの一時リポジトリを作成する。"""
@@ -148,10 +155,14 @@ def test_auto_detect_prefers_stage_on_tie(git_repo: Path) -> None:
 
 
 def test_auto_detect_excludes_current_branch(git_repo: Path) -> None:
-    """現在ブランチ自体は候補から除外される（fallback に抜ける）。"""
-    # main にいる状態で resolve すると候補は main だけ → 現在ブランチなので除外
-    # 他に候補がなければ fallback "main" に落ちる
-    assert resolver.resolve(cwd=git_repo) == "main"
+    """現在ブランチが候補名と一致していても除外され、別の候補が選ばれる。"""
+    # main から develop / stage を順に作成する（全て同一コミット）
+    _git(["checkout", "-q", "-b", "develop"], git_repo)
+    _git(["checkout", "-q", "-b", "stage"], git_repo)
+    # stage にいる状態で resolve
+    # 除外ロジックが効かないと tie-break で stage (CANDIDATES 先頭近く) が返る。
+    # 除外ロジックが効くと stage が候補から外れ、次に近い develop が選ばれる。
+    assert resolver.resolve(cwd=git_repo) == "develop"
 
 
 # ---- Fallback ----

--- a/tests/unit/test_resolve_base_branch.py
+++ b/tests/unit/test_resolve_base_branch.py
@@ -134,6 +134,19 @@ def test_auto_detect_main_plus_stage_branched_from_main(git_repo: Path) -> None:
     assert resolver.resolve(cwd=git_repo) == "main"
 
 
+def test_auto_detect_prefers_stage_on_tie(git_repo: Path) -> None:
+    """main と stage が同一コミットを指す場合、候補リストの先頭優先で stage を選ぶ。"""
+    # main から stage を作る（同一コミット、divergence なし）
+    _git(["checkout", "-q", "-b", "stage"], git_repo)
+    # stage から feature branch を作る（これも同一コミット）
+    _git(["checkout", "-q", "-b", "feat/foo"], git_repo)
+    _write_commit(git_repo, "foo.txt", "foo\n", "feat")
+
+    # main と stage は同じコミットを指す（distance 0 で同値）
+    # CANDIDATES 先頭優先で stage が選ばれる
+    assert resolver.resolve(cwd=git_repo) == "stage"
+
+
 def test_auto_detect_excludes_current_branch(git_repo: Path) -> None:
     """現在ブランチ自体は候補から除外される（fallback に抜ける）。"""
     # main にいる状態で resolve すると候補は main だけ → 現在ブランチなので除外

--- a/tests/unit/test_resolve_base_branch.py
+++ b/tests/unit/test_resolve_base_branch.py
@@ -1,0 +1,182 @@
+"""`resolve_base_branch.py` の解決ロジックのテスト。
+
+解決優先順位:
+    1. --base 明示指定
+    2. 環境変数 AI_ORCHESTRA_BASE_BRANCH
+    3. 自動推定（merge-base 距離で親を選択）
+    4. Fallback: "main"
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "packages" / "git-workflow" / "scripts" / "resolve_base_branch.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("resolve_base_branch", SCRIPT_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+resolver = _load_module()
+
+
+def _git(args: list[str], cwd: Path) -> None:
+    env = {
+        **os.environ,
+        "GIT_AUTHOR_NAME": "test",
+        "GIT_COMMITTER_NAME": "test",
+        "GIT_AUTHOR_EMAIL": "test@test",
+        "GIT_COMMITTER_EMAIL": "test@test",
+    }
+    subprocess.run(
+        ["git", *args],
+        cwd=str(cwd),
+        check=True,
+        capture_output=True,
+        env=env,
+    )
+
+
+def _write_commit(repo: Path, filename: str, content: str, message: str) -> None:
+    (repo / filename).write_text(content, encoding="utf-8")
+    _git(["add", filename], repo)
+    _git(["commit", "-q", "-m", message], repo)
+
+
+@pytest.fixture()
+def git_repo(tmp_path: Path) -> Path:
+    """main ブランチ + 初回コミット済みの一時リポジトリを作成する。"""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(["init", "-q", "--initial-branch=main", "--template="], repo)
+    _write_commit(repo, "README.md", "# test\n", "init")
+    return repo
+
+
+# ---- 明示指定 ----
+
+
+def test_explicit_base_has_highest_priority(git_repo: Path, monkeypatch) -> None:
+    monkeypatch.setenv(resolver.ENV_VAR, "stage")
+    assert resolver.resolve(explicit="develop", cwd=git_repo) == "develop"
+
+
+def test_explicit_base_strips_origin_prefix(git_repo: Path) -> None:
+    assert resolver.resolve(explicit="origin/staging", cwd=git_repo) == "staging"
+
+
+# ---- 環境変数 ----
+
+
+def test_env_var_used_when_no_explicit(git_repo: Path, monkeypatch) -> None:
+    monkeypatch.setenv(resolver.ENV_VAR, "stage")
+    assert resolver.resolve(cwd=git_repo) == "stage"
+
+
+def test_env_var_strips_origin_prefix(git_repo: Path, monkeypatch) -> None:
+    monkeypatch.setenv(resolver.ENV_VAR, "origin/stage")
+    assert resolver.resolve(cwd=git_repo) == "stage"
+
+
+def test_empty_env_var_is_ignored(git_repo: Path, monkeypatch) -> None:
+    monkeypatch.setenv(resolver.ENV_VAR, "   ")
+    # main のみのリポジトリなので自動推定 or fallback で main になる
+    assert resolver.resolve(cwd=git_repo) == "main"
+
+
+# ---- 自動推定 ----
+
+
+def test_auto_detect_main_only(git_repo: Path) -> None:
+    """main から切った feature branch は main を選ぶ。"""
+    _git(["checkout", "-q", "-b", "feat/foo"], git_repo)
+    _write_commit(git_repo, "foo.txt", "foo\n", "add foo")
+    assert resolver.resolve(cwd=git_repo) == "main"
+
+
+def test_auto_detect_main_plus_stage_branched_from_stage(git_repo: Path) -> None:
+    """stage から切った feature branch は stage を選ぶ。"""
+    # main にもう 1 コミット（stage と main が diverge するのを模す）
+    _write_commit(git_repo, "m.txt", "main only\n", "main-side")
+    # stage を作り、別コミットを乗せる
+    _git(["checkout", "-q", "-b", "stage", "HEAD~1"], git_repo)
+    _write_commit(git_repo, "s.txt", "stage only\n", "stage-side")
+    # stage から feature branch
+    _git(["checkout", "-q", "-b", "feat/foo"], git_repo)
+    _write_commit(git_repo, "foo.txt", "foo\n", "feat")
+
+    assert resolver.resolve(cwd=git_repo) == "stage"
+
+
+def test_auto_detect_main_plus_stage_branched_from_main(git_repo: Path) -> None:
+    """main+stage がある環境でも main から切ったブランチは main を選ぶ。"""
+    # stage を main から作る
+    _git(["checkout", "-q", "-b", "stage"], git_repo)
+    _write_commit(git_repo, "s.txt", "stage only\n", "stage-side")
+    # main に戻して main 先端から feature branch を作る
+    _git(["checkout", "-q", "main"], git_repo)
+    _write_commit(git_repo, "m.txt", "main only\n", "main-side")
+    _git(["checkout", "-q", "-b", "feat/foo"], git_repo)
+    _write_commit(git_repo, "foo.txt", "foo\n", "feat")
+
+    assert resolver.resolve(cwd=git_repo) == "main"
+
+
+def test_auto_detect_excludes_current_branch(git_repo: Path) -> None:
+    """現在ブランチ自体は候補から除外される（fallback に抜ける）。"""
+    # main にいる状態で resolve すると候補は main だけ → 現在ブランチなので除外
+    # 他に候補がなければ fallback "main" に落ちる
+    assert resolver.resolve(cwd=git_repo) == "main"
+
+
+# ---- Fallback ----
+
+
+def test_fallback_when_no_candidates(tmp_path: Path) -> None:
+    """候補ブランチが 1 つも存在しない場合は fallback "main" を返す。"""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(["init", "-q", "--initial-branch=feat/alone", "--template="], repo)
+    _write_commit(repo, "README.md", "# test\n", "init")
+
+    assert resolver.resolve(cwd=repo) == "main"
+
+
+# ---- CLI ----
+
+
+def test_cli_prints_resolved_branch(git_repo: Path) -> None:
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), "--base", "release"],
+        cwd=str(git_repo),
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert result.stdout.strip() == "release"
+
+
+def test_cli_cwd_argument(git_repo: Path, tmp_path: Path) -> None:
+    _git(["checkout", "-q", "-b", "feat/foo"], git_repo)
+    _write_commit(git_repo, "foo.txt", "foo\n", "feat")
+    # 別ディレクトリから --cwd で対象 repo を指定
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), "--cwd", str(git_repo)],
+        cwd=str(tmp_path),
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert result.stdout.strip() == "main"


### PR DESCRIPTION
Closes #63

## Summary

- `packages/git-workflow/scripts/resolve_base_branch.py` を新設し、PR の base branch を `--base` > `AI_ORCHESTRA_BASE_BRANCH` > merge-base 自動推定 > fallback (`main`) の優先順で解決
- 候補が同距離の場合は `staging` / `stage` 系を `main` / `master` より優先（main+stage 運用で feature PR が stage を target にする）
- `pr-create` / `issue-fix` / `pr-standards` facet を resolver 経由に切り替え、`--base <branch>` オプションを追加
- `AI_ORCHESTRA_DIR` 未設定時のサイレント失敗を防ぐガードを追加

## Testing

- [x] テスト実施済み — `pytest -q` (1268 passed / 17 skipped)、resolver 単独 13 tests pass
- [ ] 未実施（理由を記載）

## Release Note

- ユーザー向け変更点: `/pr-create --base <branch>` で base branch の明示指定が可能に。`AI_ORCHESTRA_BASE_BRANCH` 環境変数でプロジェクトのデフォルトも設定可能
- `CHANGELOG.md` 更新: Unreleased に追加済み

## Checklist

- [x] PR タイトルが GitHub Release にそのまま載っても読める
- [x] 適切なラベルを付けた (\`task\`)
- [x] ユーザー向け変更がある場合は \`CHANGELOG.md\` の \`Unreleased\` を更新した

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * Git ワークフロー用の基本ブランチ自動解決機能を追加。コマンドラインオプション、環境変数、リポジトリの自動検出により、PRの基本ブランチを柔軟に決定可能に。

* **Tests**
  * 基本ブランチ解決ロジックの包括的なユニットテストスイートを追加。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->