### PR TITLE
docs: ADR-020 stage→main リリースフローを squash + 並列 PR に確定

### DIFF
--- a/docs/adr/ADR-20260513-020.md
+++ b/docs/adr/ADR-20260513-020.md
@@ -1,0 +1,128 @@
+# ADR-020: stage → main リリースフローを squash merge + 並列 PR 方式に確定する
+
+- **ステータス**: accepted
+- **日付**: 2026-05-13
+- **決定者**: yoshihiko
+
+## コンテキスト
+
+ai-orchestra リポジトリでは 2026-04-13 に「Pattern A」として以下のブランチング戦略を採用した（observation 8593）。
+
+- `feature/*` → `stage`: **squash merge**
+- `stage` → `main`: **merge commit**（main の履歴を綺麗に保つ目的）
+- `stage` → `main` の PR は CodeRabbit が手動レビュー必須としてブロック
+
+しかし、その後に追加された GitHub Repository ruleset `main-protection`（id: 14691181）は `refs/heads/main` と `refs/heads/stage` の両方を対象に以下を強制している:
+
+- `deletion`（削除禁止）
+- `non_fast_forward`（force push 禁止）
+- **`required_linear_history`**（merge commit 禁止）
+- `pull_request`（PR 必須）
+
+`required_linear_history` が有効である以上、Pattern A 元決定の「stage → main を merge commit で取り込む」は技術的に不可能であり、決定と運用が矛盾していた。
+
+加えて、2026-04 以降の運用実態は次の通り:
+
+- PR #64, #65 は `stage` を base に正しく取り込まれた（4 月 23 日）
+- PR #66 は誤って `task/reverse` → `main` 直 PR を作成・マージしてしまった（5 月 13 日）
+- PR #67 はその誤りを是正するため `sync/main-to-stage` → `stage` の back-sync を手動で実行した
+
+stage は **dev channel**（自分の開発環境で先行利用するブランチ）として位置付けられており、main は **stable channel**（PyPI で配布される正式リリース）と明確に役割分担している。stage 自体を廃止する選択肢は要件に反する。
+
+リリース時には以下を同時に満たす必要がある:
+
+1. CHANGELOG.md の `Unreleased` セクションを当該バージョンに切り出す
+2. stage に積まれた全 feature 群を main に取り込む
+3. ruleset 制約下で main / stage への直接 push を行わない
+4. main の履歴を「1 リリース = 1 コミット」に保つ（履歴の可読性）
+
+現状の `~/.github/taskfiles/release.yml` は main-only フロー前提で書かれており、stage を経由するフローには対応していない。
+
+## 検討した選択肢
+
+### 選択肢 A: ruleset から `required_linear_history` を外し、merge commit を採用する（Pattern A 元案）
+
+- メリット: 元の Pattern A 決定をそのまま実装できる。stage の個別 squash コミットが main にもそのまま見える
+- デメリット: main の履歴に merge commit が混入し、`required_linear_history` で守られていた「履歴の線形性」が失われる。main の Network graph が複雑化し、ユーザーが優先したい「1 リリース = 1 コミット」が崩れる
+
+### 選択肢 B: stage → main を squash merge に変更し、リリース PR を `release/* → stage` と `release/* → main` の並列構成にする
+
+- メリット:
+  - `required_linear_history` を維持できる
+  - main の履歴が 1 リリース = 1 コミットに集約され可読性が高い
+  - release/\* ブランチは stage の最新を含むため、main への PR で stage の全 feature 群が一括反映される
+  - back-sync PR が不要（stage と main の内容が並列 PR で同時に一致する）
+- デメリット:
+  - main と stage の **履歴グラフが分岐し続ける**（squash が新しいハッシュを生成するため）。ただし `git diff main..stage` は常に 0 で内容ベースの差分は発生しない
+  - 並列 PR を 2 本作る必要がある
+
+### 選択肢 C: stage → main を rebase merge に変更する
+
+- メリット: linear history を維持しつつ、stage 上の個別 squash コミットがそのまま main に乗るため、main と stage の履歴が一致する
+- デメリット: main の履歴が「1 リリース = N コミット」になり、ユーザーが優先する「main 履歴の clean さ」要件に反する
+
+### 選択肢 D: stage ブランチを廃止し、GitHub Flow（feature → main 直）に戻す
+
+- メリット: トランクベース開発に近づき、運用が簡素化される。DORA 2024 でも推奨される構成
+- デメリット: stage を **dev channel として dogfooding に利用する** という本質要件を満たせない。stable channel（main / PyPI 配布）と dev channel（stage / 先行利用）の分離が崩れる
+
+## 決定
+
+**選択肢 B** を採用する。
+
+### マージ方式の確定
+
+| 区間                  | マージ方式 | auto-merge               | ゲート                |
+| --------------------- | ---------- | ------------------------ | --------------------- |
+| `feature/*` → `stage` | Squash     | なし（手動マージ）       | CodeRabbit + レビュー |
+| `release/*` → `stage` | Squash     | あり（release タスク内） | なし                  |
+| `release/*` → `main`  | Squash     | あり（release タスク内） | なし                  |
+
+`stage → main` を直接 PR にする方式ではなく、**stage から切った `release/v0.x.y` を head として stage と main の両方に並列 PR を作る** 構成とする。これにより:
+
+- `release/v0.x.y → stage` の diff は CHANGELOG コミット 1 件のみ
+- `release/v0.x.y → main` の diff は stage の全 feature 群 + CHANGELOG
+
+### リリースフロー
+
+```
+[stage ブランチ上で実行]
+
+task release VERSION=v0.x.y
+  ├─ preflight (stage 上 / 未コミット変更なし / CHANGELOG.md 存在)
+  ├─ release/v0.x.y を stage から切る
+  ├─ CHANGELOG 更新（Unreleased → v0.x.y セクションに切り出し）して commit
+  ├─ push release/v0.x.y
+  ├─ PR1: release/v0.x.y → stage  (squash + auto-merge)  ┐ 並列
+  ├─ PR2: release/v0.x.y → main   (squash + auto-merge)  ┘
+  └─ 両 PR マージ待ち
+
+task release:complete VERSION=v0.x.y
+  ├─ PR2 マージ確認
+  ├─ git checkout main && git pull
+  └─ git tag → push → GitHub Actions が Release 作成
+```
+
+### Pattern A 元決定からの変更点
+
+| 項目                              | 元 Pattern A (observation 8593) | 本 ADR の決定                                           |
+| --------------------------------- | ------------------------------- | ------------------------------------------------------- |
+| stage → main のマージ方式         | merge commit                    | **squash merge**                                        |
+| リリース PR の構成                | stage → main 単発               | **release/\* → stage と release/\* → main の並列 2 本** |
+| stage → main の CodeRabbit ゲート | 手動レビュー必須                | **不要**（feature → stage 時点でゲート済み）            |
+| back-sync の要否                  | 議論なし                        | **不要**（並列 PR で内容が同時に一致するため）          |
+
+## 影響
+
+- `~/ghq/github.com/yoshihiko555/.github/taskfiles/release.yml` の改修が必要。`STAGE_BRANCH` パラメータを追加し、未指定時は従来通り main-only フローとする後方互換構成にする
+- `facets/policies/pr-standards.md` のマージ方式記述を squash 統一に更新する
+- main / stage の Network graph は常に分岐した状態になる。これは squash merge の本質的な性質であり、`git diff main..stage` が 0 で内容ベースの差分が発生しないため、機能的・運用的な実害はない
+- 同種の運用は React (`main` + `canary`)、Vue (`main` + `next`)、Rust (stable / beta / nightly)、Next.js (`canary`) など、stable / dev channel を分けるメジャー OSS でも採用されている
+- 既存の release.yml が `gh pr merge --squash --auto` を使う前提を引き継ぐため、auto-merge ベースの実装で技術的整合性は確保できる
+- CodeRabbit の stage→main PR ブロック設定（observation 8593）は本 ADR で不要化されるため、設定済みの場合は解除する
+
+## 残余リスク
+
+- main / stage の履歴分岐が将来的に問題化するケース（例: 大規模なマージコンフリクト解消の証跡を main 上で追いたい場合）には、選択肢 A または C に再度切り替える余地を残す
+- `release/*` ブランチが stage の最新を含む前提のため、リリース実行中に stage に新規 PR がマージされると差分が混入する。これは `task release` 実行中の stage 凍結ルール（preflight で stage HEAD を固定）で抑止する
+- 並列 PR 構成のため、PR1 か PR2 のどちらかだけがマージ失敗した場合のロールバック手順を release タスク側で明示する必要がある

--- a/docs/adr/DECISIONS.md
+++ b/docs/adr/DECISIONS.md
@@ -32,3 +32,4 @@ AI Orchestra プロジェクトの意思決定記録。
 | ADR-20260421-017 | cocoindex proxy 起動は proxy-only とし、state file と reconnect 通知で扱う | accepted   | 2026-04-21 |
 | ADR-20260423-018 | cocoindex proxy 停止は supervisor の idle shutdown で扱う                  | accepted   | 2026-04-23 |
 | ADR-20260513-019 | スキル/ルールは必ずパッケージに登録する（孤立 composition の禁止）         | accepted   | 2026-05-13 |
+| ADR-20260513-020 | stage → main リリースフローを squash merge + 並列 PR 方式に確定する        | accepted   | 2026-05-13 |


### PR DESCRIPTION
## Summary

Pattern A の元決定（observation 8593, 2026-04-13）は stage → main を **merge commit** で取り込む方針だったが、GitHub Repository ruleset `main-protection` が `refs/heads/main` と `refs/heads/stage` の両方に `required_linear_history` を強制しており、技術的に merge commit が不可能だった。

この矛盾を解消するため Pattern A を改訂し、本 ADR で確定する:

- `stage` → `main` のマージ方式を **squash merge** に変更
- リリース PR を **release/\* → stage** と **release/\* → main** の **並列 2 本構成** に変更
- back-sync PR は不要（並列 PR で内容が同時に一致するため）
- CodeRabbit の stage→main ゲートは不要（feature → stage 時点でゲート済み）

## 主な変更点（vs 元 Pattern A）

| 項目 | 元 Pattern A | 本 ADR |
|------|------------|--------|
| stage → main のマージ方式 | merge commit | **squash merge** |
| リリース PR | stage → main 単発 | **release/\* → stage と release/\* → main の並列 2 本** |
| back-sync | 議論なし | **不要** |
| CodeRabbit ゲート | 手動レビュー必須 | **不要** |

## 履歴の分岐について

squash merge を採用するため、main と stage の Network graph は分岐し続けるが、`git diff main..stage` は常に 0 で内容ベースの差分は発生しない。これは React (`main` + `canary`)、Vue (`main` + `next`)、Rust (stable/beta/nightly) など stable / dev channel を分けるメジャー OSS でも同様の構成。

## Testing

- [ ] テスト実施済み
- [x] 未実施（ドキュメント追加のみ。実装は別 PR で `~/ghq/github.com/yoshihiko555/.github/taskfiles/release.yml` を改修予定）

## Release Note

- ユーザー向け変更点: なし（社内運用ルールのドキュメント化）
- \`CHANGELOG.md\` 更新: 不要（ADR 追加のみ）

## Checklist

- [x] PR タイトルが GitHub Release にそのまま載っても読める
- [x] 適切なラベルを付けた (\`documentation\`)
- [x] ユーザー向け変更がない（CHANGELOG 更新不要）

## 関連

- 元 Pattern A 決定: observation 8593
- 関連 ADR: なし（本 ADR が初）
- 後続 PR: \`~/.github/taskfiles/release.yml\` を STAGE_BRANCH 対応に改修（別リポジトリ）