### PR TITLE
docs: ADR-021 を追加し ADR-020 を supersede（リリースフローを直列方式に変更）

### DIFF
--- a/docs/adr/ADR-20260513-020.md
+++ b/docs/adr/ADR-20260513-020.md
@@ -1,8 +1,10 @@
 # ADR-020: stage → main リリースフローを squash merge + 並列 PR 方式に確定する
 
-- **ステータス**: accepted
+- **ステータス**: superseded by [ADR-021](./ADR-20260513-021.md)
 - **日付**: 2026-05-13
 - **決定者**: yoshihiko
+
+> **Note**: v0.2.7 リリースで並列 PR 方式を実運用したところ、`Automatically delete head branches: ON` 設定下で PR1 マージ時に共有 head ブランチが削除され、PR2 が孤立する致命的な問題が判明した。本 ADR は [ADR-021](./ADR-20260513-021.md) で **直列方式** に変更された（PR2 の head を永続ブランチ `stage` にすることで auto-delete を回避）。詳細は ADR-021 のコンテキストを参照。
 
 ## コンテキスト
 

--- a/docs/adr/ADR-20260513-021.md
+++ b/docs/adr/ADR-20260513-021.md
@@ -1,0 +1,121 @@
+# ADR-021: stage → main リリースフローを直列方式に変更する（ADR-020 supersede）
+
+- **ステータス**: accepted
+- **日付**: 2026-05-13
+- **決定者**: yoshihiko
+- **関連**: [ADR-020](./ADR-20260513-020.md)（superseded）
+
+## コンテキスト
+
+[ADR-020](./ADR-20260513-020.md) で確定した「並列 PR 方式」（`release/v0.x.y → stage` と `release/v0.x.y → main` を両方並列で作成する）を、v0.2.7 リリースで初めて実運用した。その結果、以下の致命的な問題が判明した。
+
+### 並列 PR 方式が破綻した経緯
+
+`task release BUMP=patch` 実行時の動作:
+
+1. `release/v0.2.7` を stage から切り、CHANGELOG 更新コミットを乗せて push
+2. **PR1** (`release/v0.2.7` → `stage`) を作成して `gh pr merge --squash --auto` を設定
+3. PR1 の CI が即時通過し、auto-merge が走って stage に取り込まれた
+4. リポジトリ設定 `Automatically delete head branches: ON` により、PR1 マージ直後に `release/v0.2.7` ブランチが削除された
+5. **PR2** (`release/v0.2.7` → `main`) の作成段階で head ブランチが存在せず、`gh pr create` が `No commits between main and release/v0.2.7, Head ref must be a branch` エラーで失敗
+
+### `Automatically delete head branches: ON` を維持する要件
+
+`Automatically delete head branches` は通常開発（`feature/* → stage`）での運用に大きく貢献する設定であり、これを OFF にすると毎リリース毎に手動でブランチ削除が必要になる。OSS / 個人 / 小規模チームの運用では維持したい設定。
+
+つまり、**並列 PR 方式は本リポジトリの運用設定と根本的に非互換**である。
+
+### 関連事象（リリース時の救済操作）
+
+実際の v0.2.7 リリースでは以下の救済が必要だった:
+
+- PR #70（stage 向け、マージ済み）はそのまま採用
+- PR #71（main 向け、失敗）を close
+- 別途 `release/v0.2.7` を再作成し、ADR 番号体系の不整合（PR #66 で発行された ADR-015 と stage 側の ADR-019 が同一内容）を一括是正したうえで PR #72 を作成、squash merge
+
+この経験から、リリースタスクは「人間の介入なしに完走できる」設計が必要であることが確認された。
+
+## 検討した選択肢
+
+### 選択肢 A: `Automatically delete head branches` を OFF にする
+
+- メリット: ADR-020 の並列方式をそのまま維持できる
+- デメリット: 通常開発（`feature/*` → `stage` の頻繁なマージ）で毎回手動ブランチ削除が必要。運用負荷が日常的に発生する
+
+### 選択肢 B: head ブランチを 2 つ作成する（並列を維持）
+
+- メリット: 並列マージで実行時間を最小化できる
+- デメリット: `release/v0.x.y-main` / `release/v0.x.y-stage` の二重命名は冗長。各 PR の差分計算も二重管理になる
+
+### 選択肢 C: 直列方式（release → stage を待ってから stage → main）
+
+- 流れ:
+  1. PR1: `release/v0.x.y → stage`（auto-merge）
+  2. PR1 のマージ完了を polling で待機
+  3. stage を pull
+  4. PR2: **`stage` → `main`**（auto-merge）
+- メリット:
+  - PR2 の head が **永続ブランチ `stage`** なので、auto-delete 対象外
+  - `Automatically delete head branches: ON` を維持できる
+  - リリース PR ごとに新ブランチを作る必要なし
+  - 設計がシンプル（中継ステップが明確）
+- デメリット:
+  - PR1 → PR2 の直列実行で CI が 2 回走るため、リリース完了まで CI×2 の時間がかかる
+  - PR1 マージの polling タイムアウト設計が必要（タスク内で 30 分上限を実装）
+
+## 決定
+
+**選択肢 C（直列方式）** を採用する。
+
+### 確定したマージ方式
+
+| 区間                  | head            | base    | マージ方式 | auto-merge         | auto-delete 影響     |
+| --------------------- | --------------- | ------- | ---------- | ------------------ | -------------------- |
+| `feature/*` → `stage` | `feature/*`     | `stage` | Squash     | なし（手動マージ） | 削除されても影響なし |
+| `release/*` → `stage` | `release/<TAG>` | `stage` | Squash     | あり               | 削除されても影響なし |
+| `stage` → `main`      | **`stage`**     | `main`  | Squash     | あり               | **対象外（永続）**   |
+
+### 確定したリリースフロー
+
+```
+[stage ブランチ上で実行]
+
+task release VERSION=v0.x.y
+  ├─ preflight (stage 上 / 未コミット変更なし / CHANGELOG.md 存在)
+  ├─ release/v0.x.y を stage から切る
+  ├─ CHANGELOG 更新（Unreleased → v0.x.y セクションに切り出し）して commit
+  ├─ push release/v0.x.y
+  ├─ PR1: release/v0.x.y → stage (squash + auto-merge)
+  ├─ ⏳ PR1 のマージ完了を polling で待機（タイムアウト 30 分）
+  ├─ git checkout stage && git pull origin stage
+  └─ PR2: stage → main (squash + auto-merge)
+
+task release:complete VERSION=v0.x.y
+  ├─ PR1 / PR2 のマージ確認
+  ├─ git checkout main && git pull
+  └─ git tag → push → GitHub Actions が Release 作成
+```
+
+### ADR-020 からの変更点
+
+| 項目                       | ADR-020（並列方式）           | ADR-021（直列方式、本 ADR）  |
+| -------------------------- | ----------------------------- | ---------------------------- |
+| PR1 と PR2 の関係          | 並列に作成・並列に auto-merge | **直列**（PR1 → 待機 → PR2） |
+| PR2 の head                | `release/v0.x.y`              | **`stage`**（永続ブランチ）  |
+| auto-delete 影響           | 致命的（PR2 が孤立する）      | **なし**（PR2 head 対象外）  |
+| release ブランチ寿命       | PR1 マージで削除              | PR1 マージで削除（変わらず） |
+| リリース完了までの CI 時間 | CI×1（並列実行）              | CI×2（直列実行）             |
+
+## 影響
+
+- `~/ghq/github.com/yoshihiko555/.github/taskfiles/release.yml` の `release:pr` および `release:verify-merged` を直列方式に書き換える必要がある（**本 ADR と同時に実装済み**: yoshihiko555/.github commit 1165e5c）
+- リリース完了までの実時間は CI×2 になるが、ユーザー操作は依然として `task release VERSION=v0.x.y` 一発で完結
+- ADR-020 で謳っていた「back-sync 不要」の特性は本 ADR でも維持される（stage を head にして main に PR を出すため、PR マージ時点で stage と main が内容ベースで一致する）
+- ADR-020 のステータスを `superseded` に変更し、`docs/adr/DECISIONS.md` の一覧表でも `superseded by ADR-021` を明記する
+- `Automatically delete head branches: ON` は維持される（ユーザー要件）
+
+## 残余リスク
+
+- PR1 マージ待ち polling のタイムアウト（30 分）を超えた場合、リリースタスクが失敗する。CI 設定が複雑化して 30 分を超える状況になった場合は、タイムアウト値の上方修正が必要
+- PR2 の head を `stage` にするため、PR2 マージ後に `stage` の HEAD が更新される（squash commit が乗る）。次回リリースの起点となる stage が前回 squash commit を含む状態になるが、`git diff stage..main` は内容ベースで 0 を維持するため運用上の実害はない
+- 直列方式は CI が安定して動作することを前提とするため、CI が flaky な場合は polling 待機中の途中失敗が発生しうる。その場合は手動で PR1 を再 trigger することで復旧可能

--- a/docs/adr/DECISIONS.md
+++ b/docs/adr/DECISIONS.md
@@ -32,4 +32,5 @@ AI Orchestra プロジェクトの意思決定記録。
 | ADR-20260421-017 | cocoindex proxy 起動は proxy-only とし、state file と reconnect 通知で扱う | accepted   | 2026-04-21 |
 | ADR-20260423-018 | cocoindex proxy 停止は supervisor の idle shutdown で扱う                  | accepted   | 2026-04-23 |
 | ADR-20260513-019 | スキル/ルールは必ずパッケージに登録する（孤立 composition の禁止）         | accepted   | 2026-05-13 |
-| ADR-20260513-020 | stage → main リリースフローを squash merge + 並列 PR 方式に確定する        | accepted   | 2026-05-13 |
+| ADR-20260513-020 | stage → main リリースフローを squash merge + 並列 PR 方式に確定する        | superseded | 2026-05-13 |
+| ADR-20260513-021 | stage → main リリースフローを直列方式に変更する（ADR-020 supersede）       | accepted   | 2026-05-13 |


### PR DESCRIPTION
## Summary

v0.2.7 リリースで ADR-020 の並列 PR 方式を初めて実運用したところ、\`Automatically delete head branches: ON\` 設定下で **PR1 マージ時に共有 head ブランチが削除され、PR2 が孤立する**致命的な問題が判明した。

本 PR で ADR-020 を supersede し、直列方式を採用する ADR-021 を新規作成する。

## 変更内容

- 追加: \`docs/adr/ADR-20260513-021.md\` — 直列方式の確定 ADR
- 変更: \`docs/adr/ADR-20260513-020.md\` — ステータスを \`accepted\` → \`superseded by ADR-021\` に変更、トップに supersede 経緯の Note を追加
- 更新: \`docs/adr/DECISIONS.md\` — 一覧表に ADR-021 を追加、ADR-020 のステータスを \`superseded\` に変更

## 直列方式の概要

| 区間 | head | base | auto-delete 影響 |
|------|------|------|-----------------|
| release/\<TAG\> → stage | release/\<TAG\> | stage | 削除されても影響なし |
| **stage → main** | **stage**（永続） | main | **対象外** |

\`task release\` は PR1 マージ完了を polling で待機（タイムアウト 30 分）した後、stage を pull して PR2 を作成する。

## 関連

- 実装側変更: yoshihiko555/.github commit 1165e5c（\`taskfiles/release.yml\` を直列方式に書き換え済み）
- 救済対応の経緯: PR #70（stage 取り込み済み）, PR #71（並列方式破綻でクローズ）, PR #72（手動再作成でリリース完了）

## Testing

- [ ] 次回リリース (v0.2.8) で \`task release\` の直列フロー動作を実検証予定
- [x] ADR / DECISIONS の整合性は手動確認済み

## Release Note

- ユーザー向け変更点: なし（社内リリース運用の決定変更）
- \`CHANGELOG.md\` 更新: 不要（ADR のみ）

## Checklist

- [x] PR タイトルが GitHub Release にそのまま載っても読める
- [x] 適切なラベルを付けた (\`documentation\`)
- [x] ユーザー向け変更がない（CHANGELOG 更新不要）