### PR TITLE
docs: ADR-022 を確定し stage 廃止を決定（main 一本化 + インライン環境変数検証）

### DIFF
--- a/docs/adr/ADR-20260513-020.md
+++ b/docs/adr/ADR-20260513-020.md
@@ -1,8 +1,10 @@
 # ADR-020: stage → main リリースフローを squash merge + 並列 PR 方式に確定する
 
-- **ステータス**: accepted
+- **ステータス**: superseded by [ADR-021](./ADR-20260513-021.md)
 - **日付**: 2026-05-13
 - **決定者**: yoshihiko
+
+> **Note**: v0.2.7 リリースで並列 PR 方式を実運用したところ、`Automatically delete head branches: ON` 設定下で PR1 マージ時に共有 head ブランチが削除され、PR2 が孤立する致命的な問題が判明した。本 ADR は [ADR-021](./ADR-20260513-021.md) で **直列方式** に変更された（PR2 の head を永続ブランチ `stage` にすることで auto-delete を回避）。詳細は ADR-021 のコンテキストを参照。
 
 ## コンテキスト
 

--- a/docs/adr/ADR-20260513-021.md
+++ b/docs/adr/ADR-20260513-021.md
@@ -1,0 +1,121 @@
+# ADR-021: stage → main リリースフローを直列方式に変更する（ADR-020 supersede）
+
+- **ステータス**: superseded by [ADR-022](./ADR-20260520-022.md)
+- **日付**: 2026-05-13
+- **決定者**: yoshihiko
+- **関連**: [ADR-020](./ADR-20260513-020.md)（superseded）/ [ADR-022](./ADR-20260520-022.md)（本 ADR を supersede）
+
+## コンテキスト
+
+[ADR-020](./ADR-20260513-020.md) で確定した「並列 PR 方式」（`release/v0.x.y → stage` と `release/v0.x.y → main` を両方並列で作成する）を、v0.2.7 リリースで初めて実運用した。その結果、以下の致命的な問題が判明した。
+
+### 並列 PR 方式が破綻した経緯
+
+`task release BUMP=patch` 実行時の動作:
+
+1. `release/v0.2.7` を stage から切り、CHANGELOG 更新コミットを乗せて push
+2. **PR1** (`release/v0.2.7` → `stage`) を作成して `gh pr merge --squash --auto` を設定
+3. PR1 の CI が即時通過し、auto-merge が走って stage に取り込まれた
+4. リポジトリ設定 `Automatically delete head branches: ON` により、PR1 マージ直後に `release/v0.2.7` ブランチが削除された
+5. **PR2** (`release/v0.2.7` → `main`) の作成段階で head ブランチが存在せず、`gh pr create` が `No commits between main and release/v0.2.7, Head ref must be a branch` エラーで失敗
+
+### `Automatically delete head branches: ON` を維持する要件
+
+`Automatically delete head branches` は通常開発（`feature/* → stage`）での運用に大きく貢献する設定であり、これを OFF にすると毎リリース毎に手動でブランチ削除が必要になる。OSS / 個人 / 小規模チームの運用では維持したい設定。
+
+つまり、**並列 PR 方式は本リポジトリの運用設定と根本的に非互換**である。
+
+### 関連事象（リリース時の救済操作）
+
+実際の v0.2.7 リリースでは以下の救済が必要だった:
+
+- PR #70（stage 向け、マージ済み）はそのまま採用
+- PR #71（main 向け、失敗）を close
+- 別途 `release/v0.2.7` を再作成し、ADR 番号体系の不整合（PR #66 で発行された ADR-015 と stage 側の ADR-019 が同一内容）を一括是正したうえで PR #72 を作成、squash merge
+
+この経験から、リリースタスクは「人間の介入なしに完走できる」設計が必要であることが確認された。
+
+## 検討した選択肢
+
+### 選択肢 A: `Automatically delete head branches` を OFF にする
+
+- メリット: ADR-020 の並列方式をそのまま維持できる
+- デメリット: 通常開発（`feature/*` → `stage` の頻繁なマージ）で毎回手動ブランチ削除が必要。運用負荷が日常的に発生する
+
+### 選択肢 B: head ブランチを 2 つ作成する（並列を維持）
+
+- メリット: 並列マージで実行時間を最小化できる
+- デメリット: `release/v0.x.y-main` / `release/v0.x.y-stage` の二重命名は冗長。各 PR の差分計算も二重管理になる
+
+### 選択肢 C: 直列方式（release → stage を待ってから stage → main）
+
+- 流れ:
+  1. PR1: `release/v0.x.y → stage`（auto-merge）
+  2. PR1 のマージ完了を polling で待機
+  3. stage を pull
+  4. PR2: **`stage` → `main`**（auto-merge）
+- メリット:
+  - PR2 の head が **永続ブランチ `stage`** なので、auto-delete 対象外
+  - `Automatically delete head branches: ON` を維持できる
+  - リリース PR ごとに新ブランチを作る必要なし
+  - 設計がシンプル（中継ステップが明確）
+- デメリット:
+  - PR1 → PR2 の直列実行で CI が 2 回走るため、リリース完了まで CI×2 の時間がかかる
+  - PR1 マージの polling タイムアウト設計が必要（タスク内で 30 分上限を実装）
+
+## 決定
+
+**選択肢 C（直列方式）** を採用する。
+
+### 確定したマージ方式
+
+| 区間                  | head            | base    | マージ方式 | auto-merge         | auto-delete 影響     |
+| --------------------- | --------------- | ------- | ---------- | ------------------ | -------------------- |
+| `feature/*` → `stage` | `feature/*`     | `stage` | Squash     | なし（手動マージ） | 削除されても影響なし |
+| `release/*` → `stage` | `release/<TAG>` | `stage` | Squash     | あり               | 削除されても影響なし |
+| `stage` → `main`      | **`stage`**     | `main`  | Squash     | あり               | **対象外（永続）**   |
+
+### 確定したリリースフロー
+
+```
+[stage ブランチ上で実行]
+
+task release VERSION=v0.x.y
+  ├─ preflight (stage 上 / 未コミット変更なし / CHANGELOG.md 存在)
+  ├─ release/v0.x.y を stage から切る
+  ├─ CHANGELOG 更新（Unreleased → v0.x.y セクションに切り出し）して commit
+  ├─ push release/v0.x.y
+  ├─ PR1: release/v0.x.y → stage (squash + auto-merge)
+  ├─ ⏳ PR1 のマージ完了を polling で待機（タイムアウト 30 分）
+  ├─ git checkout stage && git pull origin stage
+  └─ PR2: stage → main (squash + auto-merge)
+
+task release:complete VERSION=v0.x.y
+  ├─ PR1 / PR2 のマージ確認
+  ├─ git checkout main && git pull
+  └─ git tag → push → GitHub Actions が Release 作成
+```
+
+### ADR-020 からの変更点
+
+| 項目                       | ADR-020（並列方式）           | ADR-021（直列方式、本 ADR）  |
+| -------------------------- | ----------------------------- | ---------------------------- |
+| PR1 と PR2 の関係          | 並列に作成・並列に auto-merge | **直列**（PR1 → 待機 → PR2） |
+| PR2 の head                | `release/v0.x.y`              | **`stage`**（永続ブランチ）  |
+| auto-delete 影響           | 致命的（PR2 が孤立する）      | **なし**（PR2 head 対象外）  |
+| release ブランチ寿命       | PR1 マージで削除              | PR1 マージで削除（変わらず） |
+| リリース完了までの CI 時間 | CI×1（並列実行）              | CI×2（直列実行）             |
+
+## 影響
+
+- `~/ghq/github.com/yoshihiko555/.github/taskfiles/release.yml` の `release:pr` および `release:verify-merged` を直列方式に書き換える必要がある（**本 ADR と同時に実装済み**: yoshihiko555/.github commit 1165e5c）
+- リリース完了までの実時間は CI×2 になるが、ユーザー操作は依然として `task release VERSION=v0.x.y` 一発で完結
+- ADR-020 で謳っていた「back-sync 不要」の特性は本 ADR でも維持される（stage を head にして main に PR を出すため、PR マージ時点で stage と main が内容ベースで一致する）
+- ADR-020 のステータスを `superseded` に変更し、`docs/adr/DECISIONS.md` の一覧表でも `superseded by ADR-021` を明記する
+- `Automatically delete head branches: ON` は維持される（ユーザー要件）
+
+## 残余リスク
+
+- PR1 マージ待ち polling のタイムアウト（30 分）を超えた場合、リリースタスクが失敗する。CI 設定が複雑化して 30 分を超える状況になった場合は、タイムアウト値の上方修正が必要
+- PR2 の head を `stage` にするため、PR2 マージ後に `stage` の HEAD が更新される（squash commit が乗る）。次回リリースの起点となる stage が前回 squash commit を含む状態になるが、`git diff stage..main` は内容ベースで 0 を維持するため運用上の実害はない
+- 直列方式は CI が安定して動作することを前提とするため、CI が flaky な場合は polling 待機中の途中失敗が発生しうる。その場合は手動で PR1 を再 trigger することで復旧可能

--- a/docs/adr/ADR-20260520-022.md
+++ b/docs/adr/ADR-20260520-022.md
@@ -1,0 +1,217 @@
+# ADR-022: stage ブランチを廃止し、検証をインライン環境変数の一時上書きで行う（ADR-021 supersede）
+
+- **ステータス**: accepted（決定は確定。stage の**物理削除**は新フロー dry-run 検証完了後に実施する → 下記「移行の段階」）
+- **日付**: 2026-06-05 確定（2026-05-20 起案。検証メカニズムを symlink 方式からインライン環境変数方式へ改訂）
+- **決定者**: yoshihiko
+- **関連**: [ADR-020](./ADR-20260513-020.md)（superseded）/ [ADR-021](./ADR-20260513-021.md)（superseded）
+
+## コンテキスト
+
+[ADR-020](./ADR-20260513-020.md) の並列 PR 方式 → [ADR-021](./ADR-20260513-021.md) の直列 PR 方式と、stage ブランチを経由するリリースフローを 2 度にわたり再設計してきた。しかし v0.2.7 リリース以降の運用で、「stage ブランチを残す」ことそのものが構造的問題を生み続けていることが判明した。
+
+### stage 存続による構造的問題
+
+1. **squash 履歴の永続的乖離** — 全 merge を squash で行うため、stage と main の commit hash は構造的に一致しない。GitHub UI が「N ahead / M behind」を常時表示し、健全状態を示すシグナルが失われる。
+2. **二段 PR ceremony** — ADR-021 の `release/* → stage → main` 二段 PR + 30 分 polling は、本質的でない複雑性。CI 待機・タイムアウトハンドリングが障害点として残り続ける。
+3. **stage の追従責務** — stage を main と同期させ続けるコストが永続発生する。reset すれば main との差が広がり、追従すれば履歴ズレが固定化する。**どちらを選択しても整合性問題は解消しない**。
+4. **責務の曖昧さ** — stage は「リリース緩衝材」「dotfiles 検証チャネル」「履歴整理場」の三役を兼ねており、いずれにも最適化されていない。
+
+### stage が本当に必要とされていた理由
+
+問題を遡ると、stage の唯一の本質的存在理由は **「dotfiles が ai-orchestra リポジトリのファイルを直接参照しており、main を破壊する前に検証する場所が要る」** という一点だった。これは「リリースフロー」ではなく「dogfooding 検証チャネル」であり、本来 Git のブランチで表現すべき問題ではない。
+
+### 検証メカニズム実態の調査
+
+dotfiles の ai-orchestra への実パス参照は、次の 2 箇所のみであることが判明した。
+
+| 参照名             | 定義場所                              | 用途                                                                   |
+| ------------------ | ------------------------------------- | ---------------------------------------------------------------------- |
+| `AI_ORCHESTRA_DIR` | `~/.claude/settings.json` の `env`    | Claude Code が hooks を実行時に直接参照／SessionStart の sync 元になる |
+| `OCHE_ROOT`        | `~/.zsh/aliases.zsh`（`orche` alias） | `orchestra-manager.py` の実行パス（手動コマンド）                      |
+
+`AI_ORCHESTRA_DIR` は **「配布元リポジトリへのポインタ」** であり、各プロジェクトの Claude Code は hook を起動するたびに `$AI_ORCHESTRA_DIR/packages/.../hooks/*.py` を直接実行する。すなわち **このポインタが指すディレクトリの内容を書き換えた瞬間、次に起動する全プロジェクトの Claude Code がその新コードで動く**。これが「main を壊すと全環境が即座に壊れる」理由であり、検証チャネルの本質である。
+
+決定的な事実として、Claude Code の環境変数の優先順位は **「シェル/インラインで指定した環境変数 > settings.json の `env`」** である（公式ドキュメント env-vars.md: "Shell-exported variables take precedence over settings file variables"）。したがって `settings.json` に安定版を据え置いたまま、検証時だけインライン指定（`AI_ORCHESTRA_DIR=<path> claude`）で一時的に上書きできる。検証チャネルを「Git ブランチ」でも「グローバル symlink」でもなく、**「起動 1 回ぶんの環境変数上書き」** で表現できる。
+
+> **重要（2 変数の非対称性）**: `AI_ORCHESTRA_DIR` は hooks／sync が参照するが、`OCHE_ROOT` は手動 `orche` コマンド専用で、**両者は独立して解決される**。検証時に `AI_ORCHESTRA_DIR` だけを上書きすると、検証セッション内で `orche sync` を叩いた瞬間に `OCHE_ROOT`（安定版）から sync され検証環境が汚染される。よって**検証時は 2 変数を同時に上書きする**ことを必須とする（下記フロー参照）。
+
+## 検討した選択肢
+
+### 選択肢 A: stage を可動ラベル化（責務縮小）
+
+- メリット: 既存運用との互換性が高い
+- デメリット: 追従責務が構造的に残る。reset しても次の検証で再び開く「綺麗じゃない」状態が永続する
+
+### 選択肢 B: グローバル symlink の向き先切替（旧採用案）
+
+- 流れ: `~/.config/ai-orchestra` を symlink にして dotfiles から参照し、検証時に `ln -sfn` で向き先を feature worktree へ切替える
+- メリット: 仕組み自体はシンプル
+- デメリット: **グローバルな mutable state** が残る。symlink を戻し忘れると全シェル・全プロジェクトが feature 版を見続ける。切替・復帰が手動で、戻し作業の認知負荷がある
+
+### 選択肢 C: detached HEAD で固定パス運用
+
+- デメリット: `git status` が常時 "HEAD detached" を表示する認知負荷、孤児コミット事故のリスク
+
+### 選択肢 D: dotfiles 内で git subtree / submodule 管理
+
+- デメリット: dotfiles 側の大幅改修が必要、個人運用には過剰
+
+### 選択肢 E: インライン環境変数の一時上書き + メインディレクトリ main 固定（本 ADR の採用案）
+
+- 流れ:
+  - メインディレクトリ `~/ghq/.../ai-orchestra` は **常に main をチェックアウト**したまま固定（ここでブランチを切り替えない）
+  - feature 開発は `git worktree add` で別ディレクトリに切り出して行う
+  - dotfiles（`settings.json` / `aliases.zsh`）はメインディレクトリを指したまま据え置く → **既定では全プロジェクトが常に安定版 main を見る**
+  - 検証時だけ、起動 1 回ぶん `OCHE_ROOT=<wt> AI_ORCHESTRA_DIR=<wt> claude` で 2 変数を同時にインライン上書きする
+- メリット:
+  - Git は main 一本で完結（stage の追従責務・squash 履歴ズレが消える）
+  - 二段 PR + polling が不要（main 直 PR + 直タグ）
+  - **グローバルな mutable state を持たない**。検証はそのセッション内に閉じ、ウィンドウを閉じれば hooks のランタイム参照は既定（安定版）へ戻る → **戻し忘れ事故が構造的に発生しない**
+  - **dotfiles の値は変更不要**（現状の値が既にメインディレクトリを指す）。symlink も新設しない
+  - 既定が常に安定版 main である状態が、メインディレクトリを動かさない運用によって構造的に保証される
+- デメリット:
+  - 「メインディレクトリではブランチを切り替えず、開発は worktree で行う」という運用規律を守る必要がある（規律違反は git が技術的に阻止しない → 検知手段で緩和、下記リスク参照）
+  - SessionStart の sync 成果物（agents/config）はプロジェクト側に残る（下記「検証の正確な挙動」参照）
+  - 複数端末で「検証状態を継続したい」場合、端末ごとにインライン指定が要る（ただし常用シナリオではない）
+
+## 決定
+
+**選択肢 E（インライン環境変数の一時上書き + メインディレクトリ main 固定 worktree 運用）** を採用する。
+
+### 確定したブランチ構成
+
+| ブランチ    | 役割                                   | 履歴特性                   |
+| ----------- | -------------------------------------- | -------------------------- |
+| `main`      | 履歴の本流、ソースの真実、リリース対象 | 線形 + squash merge        |
+| `feature/*` | 個別の開発作業（worktree で並行）      | 短命、main に PR で squash |
+| ~~`stage`~~ | **廃止**（物理削除は dry-run 後）      | —                          |
+
+### 確定した検証メカニズム
+
+```
+~/ghq/.../ai-orchestra              ← Git リポ、main 固定（ここではブランチを切り替えない）
+                                       dotfiles はこのパスを指す = 既定の安定版
+~/ghq/.../ai-orchestra-feat-X       ← worktree、feature 開発拠点
+
+[検証] 2 変数を同時に上書きして起動する
+OCHE_ROOT=~/ghq/.../ai-orchestra-feat-X \
+AI_ORCHESTRA_DIR=~/ghq/.../ai-orchestra-feat-X claude
+  → この起動セッションだけ feature 版の hooks/skills/agents で動く
+  → ウィンドウを閉じれば、次回起動から既定（安定版 main）に自動復帰
+```
+
+`settings.json` の `AI_ORCHESTRA_DIR` および `aliases.zsh` の `OCHE_ROOT` はメインディレクトリを指したまま **据え置く**（削除も変更もしない）。インライン指定が settings.json より優先されるため、据え置きと一時上書きが両立する。2 変数の同時指定は煩雑なので、`orche-validate <worktree>` wrapper（下記「影響」）で 1 コマンドに集約することを**推奨**する。
+
+### 検証の正確な挙動（sync 成果物の扱い）
+
+検証セッションの効果は 2 層に分かれる。両方を理解した上で運用する。
+
+1. **hooks のランタイム参照** — hook は起動のたびに `$AI_ORCHESTRA_DIR/packages/.../hooks/*.py` を直接実行する。これはセッション限りで、ウィンドウを閉じれば次回は既定（安定版）に戻る。
+2. **SessionStart の sync 成果物** — `sync-orchestra.py` は SessionStart で `$AI_ORCHESTRA_DIR` から**検証先プロジェクトの `.claude/agents/`・`.claude/config/` に上書き同期**する。この成果物は**プロジェクト側に残り**、ウィンドウを閉じても消えない。次にそのプロジェクトを安定版で開いた SessionStart で再 sync されて戻る。
+
+したがって、検証は**本番作業中のプロジェクトではなく、使い捨ての検証用プロジェクト、または ai-orchestra リポ自身**で行うことを推奨する。本番プロジェクトで検証する場合は、検証後にそのプロジェクトを安定版セッションで一度開いて再 sync させる。
+
+### 確定した日常フロー
+
+```
+[開発]
+git worktree add ../ai-orchestra-feat-X -b feature/X origin/main
+cd ../ai-orchestra-feat-X
+# 実装、コミット
+
+[検証]（推奨: wrapper 利用 / 生コマンドは 2 変数同時指定）
+orche-validate ~/ghq/.../ai-orchestra-feat-X
+# = OCHE_ROOT=<wt> AI_ORCHESTRA_DIR=<wt> claude を検証用プロジェクトで起動
+
+[PR]
+gh pr create --base main --title "feat: X"
+# main に squash merge
+
+[後始末]
+git worktree remove ../ai-orchestra-feat-X
+```
+
+### 確定したリリースフロー
+
+```
+[リリース PR]
+git worktree add ../ai-orchestra-release -b release/vX.Y.Z origin/main
+cd ../ai-orchestra-release
+# CHANGELOG.md の Unreleased → vX.Y.Z セクションへフラッシュ
+git commit -am "chore(release): vX.Y.Z"
+git push -u origin release/vX.Y.Z
+gh pr create --base main
+# squash merge
+
+[タグ]
+cd ~/ghq/.../ai-orchestra
+git pull --ff-only origin main
+git tag vX.Y.Z && git push origin vX.Y.Z
+# GitHub Actions が Release を自動生成
+```
+
+stage は存在しないため、二段 PR / 30 分 polling は不要。
+
+### ADR-020/021 からの変更点
+
+| 項目             | ADR-020（並列）           | ADR-021（直列）           | **ADR-022（本 ADR）**              |
+| ---------------- | ------------------------- | ------------------------- | ---------------------------------- |
+| stage の存在     | あり                      | あり                      | **なし**                           |
+| リリース PR 段数 | 2（並列）                 | 2（直列、polling 付き）   | **1（リリース PR のみ）**          |
+| 検証メカニズム   | stage への merge          | stage への merge          | **インライン環境変数の一時上書き** |
+| squash 履歴ズレ  | 発生                      | 発生                      | **発生しない**                     |
+| auto-delete 影響 | 致命的（PR2 head が孤立） | なし（PR2 head が stage） | **無関係**                         |
+| 自動化複雑度     | 高（並列 head 管理）      | 中（polling 必要）        | **低**                             |
+
+## 移行の段階
+
+本 ADR の決定は確定だが、実行は段階的に行う（詳細チェックリストは `.claude/Plans.md`）。
+
+1. **ADR-022 を main に確定**（本 ADR の取り込み）— origin/main から切り直した PR で行う（下記「既存 stage の処分」）
+2. **新フローの dry-run 検証** — `AI_ORCHESTRA_DIR=<wt> claude` で feature 版 hook が実際に動くこと、インライン上書きが settings.json に勝つことを実環境で確認
+3. **stage 物理削除** — dry-run が通った後に実施（rollback 余地を確保するため、それまで stage は残す）
+4. **release task 書換** — 下記参照
+
+## 影響
+
+### コードベース変更
+
+- `docs/adr/DECISIONS.md`: ADR-021 を `superseded` に変更し、本 ADR を追加（本 PR に含む）
+- `docs/adr/ADR-20260513-021.md`: ステータス `accepted` → `superseded`、関連リンクに ADR-022 追加（本 PR に含む）
+- `docs/adr/ADR-20260513-020.md`: ADR-021 導入時に `superseded by ADR-021` 化済み。本 PR では main の `accepted` 版をその superseded 版へ更新する形でバンドルされる（ADR-022 自体による追加変更はなし）
+- `~/ghq/github.com/yoshihiko555/.github/taskfiles/release.yml`: 二段 PR + polling から「リリース PR + main 直タグ」方式に書き換え（**本 PR に含まない。Plans.md Phase 5 で別途対応**）
+- `Taskfile.yml`: release タスクの `STAGE_BRANCH` 引数を削除（**本 PR に含まない。Plans.md Phase 5 で別途対応**）
+
+### dotfiles リポジトリ変更
+
+- **値の変更は不要**。`settings.json` の `AI_ORCHESTRA_DIR`、`aliases.zsh` の `OCHE_ROOT` はメインディレクトリを指したまま据え置く（既に安定版を指している）
+- **推奨**: `orche-validate <worktree>` / `orche-reset` の薄い shell function を追加する。`orche-validate` は `OCHE_ROOT` と `AI_ORCHESTRA_DIR` を**同時に**上書きしたサブシェルで `claude` を起動し、検証起動を 1 コマンドに集約する（2 変数の片方上書き漏れ事故を防ぐため、任意ではなく推奨とする）
+
+### ローカル環境変更
+
+- symlink は作成しない（旧 symlink 案は不採用）
+- メインディレクトリ `~/ghq/.../ai-orchestra` を main に戻し、以後ここでブランチを切り替えない運用に移行する
+
+### GitHub リポジトリ設定変更
+
+- `stage` ブランチを削除（dry-run 検証後。GitHub 上 + ローカル）
+- branch protection から stage ルールを削除
+- `main` の branch protection は維持（squash merge only / linear history / PR required）
+- `Automatically delete head branches: ON` は維持
+
+### 既存 stage の処分
+
+main は既に `f159cd9`（PR #72, v0.2.7）で stage の全内容を取り込んでおり、stage と main の**正味の内容差分は ADR-020(superseded 化)/021/022 + DECISIONS の 4 ファイルのみ**（二点 diff `main..HEAD` = 336 行）。`git log` 上は履歴分岐で多数の commit が ahead/behind に見えるが、コードは同一である。
+
+ただし両者は古い merge-base から履歴分岐しているため、stage 派生ブランチを main へ**直接 PR するとコンフリクトが発生する**（`merge-tree` で `ADR-20260513-020.md` の add/add と `DECISIONS.md` の content コンフリクトを確認済み）。
+
+したがって、**origin/main から新ブランチを切り、上記 4 ファイルだけを 1 commit で乗せてクリーンな PR を作成**する。これによりコンフリクトなく ADR-022 を main に確定できる。**この PR では stage を削除しない**（上記「移行の段階」3 に従う）。
+
+## 残余リスク
+
+- **インライン上書きの優先順位**: 「インライン env > settings.json env」が前提。公式ドキュメントで確認済みだが、stage 物理削除の前に実環境で 1 度 dry-run 検証する
+- **2 変数の上書き漏れ（OCHE_ROOT 非対称）**: `AI_ORCHESTRA_DIR` だけ上書きして `orche sync` を叩くと安定版から sync され検証環境が汚染される。`orche-validate` wrapper で 2 変数同時上書きを標準化して緩和する
+- **sync 成果物の残留**: SessionStart の sync はプロジェクト側に残る（上記「検証の正確な挙動」）。検証は使い捨て環境または ai-orchestra リポ自身で行い、本番プロジェクトで検証した場合は安定版で一度開いて再 sync させる
+- **メインディレクトリでのブランチ切替事故**: 規律違反を git は阻止しない。検知手段として `.git/hooks/post-checkout` で main 以外への切替時に警告を出す、または `orche-validate` 内で `git -C <main> branch --show-current` が `main` であることを assert する
+- **将来チームメンバ参画時**: 個人運用前提の方式は他人マシンへの展開が難しい（全メンバの dotfiles に変数定義が要る／worktree 命名規約／インライン手順の文書化が必要）。チーム化のタイミングで env var indirection を主軸にした再設計（または subtree 方式）へ移行する
+- **macOS 以外の環境**: 現状運用環境は macOS のみ。インライン環境変数指定は POSIX シェル標準であり移植性は高い

--- a/docs/adr/DECISIONS.md
+++ b/docs/adr/DECISIONS.md
@@ -11,25 +11,27 @@ AI Orchestra プロジェクトの意思決定記録。
 
 ## 一覧
 
-| #                | タイトル                                                                   | ステータス | 日付       |
-| ---------------- | -------------------------------------------------------------------------- | ---------- | ---------- |
-| ADR-20260216-001 | docs ディレクトリのカテゴリ分類と ADR 導入                                 | accepted   | 2026-02-16 |
-| ADR-20260219-002 | startproject 実装フェーズの明示化と Codex 例外の厳格化                     | accepted   | 2026-02-19 |
-| ADR-20260223-003 | Codex CLI 実装委譲のデッドロック解消と Implementation Method 強制          | accepted   | 2026-02-23 |
-| ADR-20260223-004 | task-memory サマリー表示仕様の明確化と marker 設定の堅牢化                 | accepted   | 2026-02-23 |
-| ADR-20260223-005 | Codex/Gemini 運用記述の config-driven 統一                                 | accepted   | 2026-02-23 |
-| ADR-20260302-006 | cocoindex v2: mcp-proxy による MCP 共有化とポート自動導出                  | accepted   | 2026-03-02 |
-| ADR-20260307-007 | cocoindex proxy モードのデフォルト設定維持（stdio）                        | accepted   | 2026-03-07 |
-| ADR-20260308-008 | サブエージェント model の config-driven 自動パッチ                         | accepted   | 2026-03-08 |
-| ADR-20260313-009 | CLI 間コンテキスト共有のファイルベース設計                                 | accepted   | 2026-03-13 |
-| ADR-20260315-010 | Faceted Prompting によるスキル・ルールのファセット分解と自動生成           | accepted   | 2026-03-15 |
-| ADR-20260322-011 | manifest-SSOT アーキテクチャ（facets 正本化・パッケージ skills 廃止）      | accepted   | 2026-03-22 |
-| ADR-20260322-012 | facet build 完全委譲（rules 廃止・knowledge/scripts 層導入）               | accepted   | 2026-03-22 |
-| ADR-20260409-013 | PR 作成スキル追加と issue-workflow パッケージの git-workflow への改名      | accepted   | 2026-04-09 |
-| ADR-20260412-014 | quality-gates に独立したテスト改ざん検出 Hook を追加                       | accepted   | 2026-04-12 |
-| ADR-20260414-015 | agent-routing の未分類リサーチ入力は researcher 基点で解決する             | accepted   | 2026-04-14 |
-| ADR-20260419-016 | quality gate の判定は quality-gates が担い、audit は記録と集計に限定する   | accepted   | 2026-04-19 |
-| ADR-20260421-017 | cocoindex proxy 起動は proxy-only とし、state file と reconnect 通知で扱う | accepted   | 2026-04-21 |
-| ADR-20260423-018 | cocoindex proxy 停止は supervisor の idle shutdown で扱う                  | accepted   | 2026-04-23 |
-| ADR-20260513-019 | スキル/ルールは必ずパッケージに登録する（孤立 composition の禁止）         | accepted   | 2026-05-13 |
-| ADR-20260513-020 | stage → main リリースフローを squash merge + 並列 PR 方式に確定する        | accepted   | 2026-05-13 |
+| #                | タイトル                                                                                | ステータス | 日付       |
+| ---------------- | --------------------------------------------------------------------------------------- | ---------- | ---------- |
+| ADR-20260216-001 | docs ディレクトリのカテゴリ分類と ADR 導入                                              | accepted   | 2026-02-16 |
+| ADR-20260219-002 | startproject 実装フェーズの明示化と Codex 例外の厳格化                                  | accepted   | 2026-02-19 |
+| ADR-20260223-003 | Codex CLI 実装委譲のデッドロック解消と Implementation Method 強制                       | accepted   | 2026-02-23 |
+| ADR-20260223-004 | task-memory サマリー表示仕様の明確化と marker 設定の堅牢化                              | accepted   | 2026-02-23 |
+| ADR-20260223-005 | Codex/Gemini 運用記述の config-driven 統一                                              | accepted   | 2026-02-23 |
+| ADR-20260302-006 | cocoindex v2: mcp-proxy による MCP 共有化とポート自動導出                               | accepted   | 2026-03-02 |
+| ADR-20260307-007 | cocoindex proxy モードのデフォルト設定維持（stdio）                                     | accepted   | 2026-03-07 |
+| ADR-20260308-008 | サブエージェント model の config-driven 自動パッチ                                      | accepted   | 2026-03-08 |
+| ADR-20260313-009 | CLI 間コンテキスト共有のファイルベース設計                                              | accepted   | 2026-03-13 |
+| ADR-20260315-010 | Faceted Prompting によるスキル・ルールのファセット分解と自動生成                        | accepted   | 2026-03-15 |
+| ADR-20260322-011 | manifest-SSOT アーキテクチャ（facets 正本化・パッケージ skills 廃止）                   | accepted   | 2026-03-22 |
+| ADR-20260322-012 | facet build 完全委譲（rules 廃止・knowledge/scripts 層導入）                            | accepted   | 2026-03-22 |
+| ADR-20260409-013 | PR 作成スキル追加と issue-workflow パッケージの git-workflow への改名                   | accepted   | 2026-04-09 |
+| ADR-20260412-014 | quality-gates に独立したテスト改ざん検出 Hook を追加                                    | accepted   | 2026-04-12 |
+| ADR-20260414-015 | agent-routing の未分類リサーチ入力は researcher 基点で解決する                          | accepted   | 2026-04-14 |
+| ADR-20260419-016 | quality gate の判定は quality-gates が担い、audit は記録と集計に限定する                | accepted   | 2026-04-19 |
+| ADR-20260421-017 | cocoindex proxy 起動は proxy-only とし、state file と reconnect 通知で扱う              | accepted   | 2026-04-21 |
+| ADR-20260423-018 | cocoindex proxy 停止は supervisor の idle shutdown で扱う                               | accepted   | 2026-04-23 |
+| ADR-20260513-019 | スキル/ルールは必ずパッケージに登録する（孤立 composition の禁止）                      | accepted   | 2026-05-13 |
+| ADR-20260513-020 | stage → main リリースフローを squash merge + 並列 PR 方式に確定する                     | superseded | 2026-05-13 |
+| ADR-20260513-021 | stage → main リリースフローを直列方式に変更する（ADR-020 supersede）                    | superseded | 2026-05-13 |
+| ADR-20260520-022 | stage ブランチを廃止し、検証をインライン環境変数の一時上書きで行う（ADR-021 supersede） | accepted   | 2026-06-05 |


### PR DESCRIPTION
## 概要

ブランチ戦略を **main 一本化（stage 廃止）** に確定する意思決定記録。検証はインライン環境変数（`OCHE_ROOT` + `AI_ORCHESTRA_DIR`）の一時上書き + メインディレクトリ main 固定 worktree 運用で行う。

## 背景

ADR-020（並列 PR）→ ADR-021（直列 PR + 30分 polling）→ **ADR-022（stage 廃止）**。stage の squash 履歴の永続的乖離・追従責務・二段 PR ceremony を構造的に解消する。

## 変更内容

- `ADR-20260520-022.md`: 新規（採用案 = インライン環境変数方式。ADR-021 を supersede）
- `ADR-20260513-021.md`: `accepted` → `superseded by ADR-022`
- `ADR-20260513-020.md`: ADR-021 導入分の superseded 化をバンドル
- `DECISIONS.md`: 一覧表を 020/021 superseded・022 accepted に更新

## マージ方法（コンフリクト回避）

main は v0.2.7 (#72) で stage 内容を取り込み済みのため、正味差分は ADR 4 ファイルのみ。履歴分岐によるコンフリクトを避けるため **origin/main から切り直し**済み。

## stage の扱い

本 PR では **stage を削除しない**。新フロー dry-run 検証後に別途削除する（rollback 余地確保）。

## レビュー

`/review design`（spec + architecture）実施済み。Critical/High 指摘（OCHE_ROOT 非対称・sync 成果物残留・検知手段・stage 処分の実態）を反映済み。

## changelog

更新不要（ADR ドキュメントのみ。ユーザー向け機能変更なし）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)