### PR TITLE
chore: release タスクから STAGE_BRANCH を削除（ADR-022 main 直フロー）

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -15,8 +15,6 @@ includes:
     vars:
       ORCHESTRA_DIR: "{{.ORCHESTRA_DIR}}"
   rel:
+    # ADR-022: stage 廃止により main 直 PR + 直タグ方式（STAGE_BRANCH は渡さない）
     taskfile: ~/ghq/github.com/yoshihiko555/.github/taskfiles/release.yml
     flatten: true
-    vars:
-      # ADR-020: stage 経由フローを採用。release/* を stage と main の両方に並列 PR で出す
-      STAGE_BRANCH: stage


### PR DESCRIPTION
## 概要

ADR-022（stage 廃止・main 一本化）に伴い、`Taskfile.yml` の release include から `STAGE_BRANCH: stage` を削除。共有 `release.yml` の **main 直 PR + 直タグ**フローを使う。

## 背景

stage 廃止済み（PR #74）。release.yml 側も main 直専用に清掃する（yoshihiko555/.github の別 PR）。本 PR は ai-orchestra 側で STAGE_BRANCH を渡さないようにする変更。

## 確認

`task --list` / `task --dry release` で構文整合を確認済み。

## changelog

更新不要（内部運用の変更。ユーザー向け機能変更なし）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * リリースワークフローの処理方式を更新しました。メインブランチへのPR直接マージと直接タグ付けに対応する新しい運用方針に変更されています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->