### PR TITLE
chore: cocoindex-code MCP サーバー設定を stdio モードに変更

### DIFF
--- a/.claude/orchestra.json
+++ b/.claude/orchestra.json
@@ -50,5 +50,5 @@
     "config/git-workflow/sandbox-requirements.json",
     "config/image-generation/image-generation.yaml"
   ],
-  "last_sync": "2026-06-12T03:10:44.236927+00:00"
+  "last_sync": "2026-06-12T07:12:04.393664+00:00"
 }

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -19,4 +19,6 @@ enabled = true
 path = ".codex/skills/context-loader"
 
 [mcp_servers.cocoindex-code]
-url = "http://127.0.0.1:8887/mcp"
+command = "uvx"
+args = ["--prerelease=explicit", "--with", "cocoindex>=1.0.0a16", "cocoindex-code@latest"]
+enabled = true

--- a/.gemini/settings.json
+++ b/.gemini/settings.json
@@ -26,7 +26,13 @@
   },
   "mcpServers": {
     "cocoindex-code": {
-      "url": "http://127.0.0.1:8887/sse"
+      "command": "uvx",
+      "args": [
+        "--prerelease=explicit",
+        "--with",
+        "cocoindex>=1.0.0a16",
+        "cocoindex-code@latest"
+      ]
     }
   }
 }

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,8 +1,14 @@
 {
   "mcpServers": {
     "cocoindex-code": {
-      "type": "sse",
-      "url": "http://127.0.0.1:8887/sse"
+      "command": "uvx",
+      "args": [
+        "--prerelease=explicit",
+        "--with",
+        "cocoindex>=1.0.0a16",
+        "cocoindex-code@latest"
+      ],
+      "type": "stdio"
     }
   }
 }


### PR DESCRIPTION
## Summary

- cocoindex-code MCP サーバーの接続方式を SSE/HTTP proxy から stdio（uvx）に変更
  - `.mcp.json`: `type: sse` + URL → `command: uvx` + `type: stdio`
  - `.codex/config.toml`: `url` → `command/args` 形式
  - `.gemini/settings.json`: `url` → `command/args` 形式
- `.claude/orchestra.json` の `last_sync` タイムスタンプを更新

## Testing

- [x] 未実施（MCP 設定変更のため動作確認は手動 `/mcp` リコネクトで確認）

## Release Note

- ユーザー向け変更点: cocoindex-code MCP サーバーのデフォルト接続方式が proxy モード（HTTP/SSE）から stdio モードに変更されます。proxy を使用していた場合は `cocoindex.local.yaml` で `proxy.enabled: true` を設定してください。
- `CHANGELOG.md` 更新: 対象外（内部設定変更のみ）

## Checklist

- [x] PR タイトルが GitHub Release にそのまま載っても読める
- [x] 適切なラベルを付けた (`task`)
- [x] ユーザー向け変更なし（設定ファイルの内部変更のみ）