### PR TITLE
fix(image-gen): codex 0.140.0 で壊れた画像生成を修正

### DIFF
--- a/.agents/skills/image-gen/SKILL.md
+++ b/.agents/skills/image-gen/SKILL.md
@@ -128,6 +128,9 @@ Task(subagent_type="image-generator", prompt="""
 - **モデル**: 既定 `gpt-5.5`（`gpt-5.3-codex` 等のコーディングモデルは image_gen 非対応）。
   変更は `image-generation` パッケージ config（`config/image-generation.yaml` の `image_model`）で行う。
 - **sandbox**: 画像生成コマンドのみ Claude Code 側 Bash を `dangerouslyDisableSandbox: true` で実行する
-  （Codex の app-server 起動が層1 sandbox に阻害されるため）。Codex 側は通常の `workspace-write`。
+  （Codex の app-server 起動が層1 sandbox に阻害されるため）。Codex 側（層2）は
+  `workspace-write` のまま（FS は repo 内に OS 強制で限定）、`image_gen` の backend 通信のため
+  `network_access=true` だけを開放する。`danger-full-access` は使わない（詳細は image-generator
+  エージェント定義の Sandbox Policy）。
 - **レートリミット**: 連打で発生する。1 リクエストにつき 1 回だけ生成を試みる。
 - **出力先**: デフォルト `generated-images/` は `.gitignore` 管理。成果物はユーザーが目視確認する前提。

--- a/.agents/skills/image-gen/SKILL.md
+++ b/.agents/skills/image-gen/SKILL.md
@@ -132,5 +132,8 @@ Task(subagent_type="image-generator", prompt="""
   `workspace-write` のまま（FS は repo 内に OS 強制で限定）、`image_gen` の backend 通信のため
   `network_access=true` だけを開放する。`danger-full-access` は使わない（詳細は image-generator
   エージェント定義の Sandbox Policy）。
+- **`--enable imagegenext` 必須**（codex 0.140.0）: これが無いと exec モードで生成画像が
+  ディスク保存されず（`saved_path` 未populate）、結果を取得できない。0.137.0 からの回帰。
+  詳細は image-generator エージェント定義の Step 3。
 - **レートリミット**: 連打で発生する。1 リクエストにつき 1 回だけ生成を試みる。
 - **出力先**: デフォルト `generated-images/` は `.gitignore` 管理。成果物はユーザーが目視確認する前提。

--- a/.claude/agents/image-generator.md
+++ b/.claude/agents/image-generator.md
@@ -31,23 +31,47 @@ and stop (do NOT draw a placeholder yourself).
 
 Do NOT hardcode values that exist in the config; always read them first.
 
-## Sandbox Policy (IMPORTANT — intentional exception)
+## Sandbox Policy (IMPORTANT — two layers, read carefully)
 
 This agent is the **single** deliberate exception to the project-wide rule
 "`dangerouslyDisableSandbox` is never used". The exception lives here and nowhere
 else — callers (skills/orchestrator) must NOT pass sandbox instructions to this
 agent; this Sandbox Policy is the only authority.
 
-- The image generation Bash command (Step 3 only) **MUST** run with
-  `dangerouslyDisableSandbox: true`.
+There are two independent sandbox layers around the `codex exec` call. The
+security boundary is **layer 2** (Codex's own OS-enforced seatbelt), NOT prompt
+wording.
+
+- **Layer 1 — Claude Code Bash sandbox**: the image generation Bash command
+  (Step 3 only) **MUST** run with `dangerouslyDisableSandbox: true`.
   Reason: Codex spins up an in-process app-server to call `image_gen`, and the
-  Claude Code Bash sandbox (layer 1) blocks that with `Operation not permitted`.
-- Codex's own sandbox (layer 2) stays at the normal `--sandbox workspace-write`.
-  The dangerous Codex flag `--dangerously-bypass-approvals-and-sandbox` is **NOT** used.
-- Every other Bash command in this workflow (path validation, file inspection)
-  runs under the **normal sandbox**. Only the one `codex exec` line is exempt.
-- Because layer 1 is off for that one command, input validation (Steps 1–2) is a
-  hard security boundary, not a nicety. Do not skip it.
+  Claude Code Bash sandbox blocks that process/socket spawn with
+  `Operation not permitted`. Every other Bash command in this workflow (path
+  validation, file inspection, copy) runs under the **normal sandbox**. Only the
+  one `codex exec` line is exempt.
+- **Layer 2 — Codex's own sandbox**: stays at `--sandbox workspace-write` **with
+  network access enabled** via `-c sandbox_workspace_write.network_access=true`.
+  - `workspace-write` keeps the filesystem **OS-restricted to the repo + /tmp**:
+    Codex cannot read, write, or delete anything outside the workspace (e.g.
+    `~/.ssh`, repo-external `.env`, other projects) regardless of what the
+    (untrusted) prompt says. This is a deterministic, kernel-enforced boundary —
+    do NOT weaken it.
+  - `network_access=true` is required because codex 0.140.0's `image_gen`
+    app-server reaches its backend over the network; with the default restricted
+    network it fails app-server init with `Operation not permitted`.
+  - The image itself is saved by Codex's own process (not a model-generated shell
+    command) to `~/.codex/generated_images/<session>/`, so it is unaffected by
+    the workspace-write filesystem restriction.
+  - **NEVER** use `--sandbox danger-full-access` or
+    `--dangerously-bypass-approvals-and-sandbox` here. They remove the
+    filesystem boundary (whole-disk read/write/delete) and were explicitly
+    rejected: the agent could be invoked with an untrusted prompt, so the OS
+    boundary must remain.
+- **Residual risk** (accepted): with network open and repo files readable, repo
+  contents could in principle be exfiltrated. Input validation (Steps 1–2) and
+  the constrained Codex prompt (Step 2) are defense-in-depth on top of the OS
+  boundary — keep them. Do not feed this agent prompts from fully untrusted
+  automated sources.
 
 ## Implementation Method (required)
 
@@ -86,31 +110,107 @@ PROMPT_TEXT=$(cat <<'PROMPT_EOF'
 PROMPT_EOF
 )
 # Build the instruction with parameter expansion (no eval, no nested quoting):
-FULL_PROMPT="Generate the following image: ${PROMPT_TEXT}. \
-Save the file to ${RESOLVED}. Use your built-in image generation tool. \
-IMPORTANT: if image generation fails (e.g. rate limit / TooManyRequests), do NOT \
-draw a fallback with Pillow, PIL, ImageMagick, matplotlib or any code-drawn \
-placeholder; report the failure explicitly instead."
+FULL_PROMPT="Use your built-in image_gen tool to generate the following image: \
+${PROMPT_TEXT}. \
+Accept whatever image_gen returns — do NOT judge, reject, or regenerate it for \
+quality, color, or composition reasons. Do NOT delete any generated file. \
+Do NOT read, write, or run anything unrelated to this single image generation. \
+After generation, print the absolute path of the image file image_gen saved on disk. \
+IMPORTANT: if image generation fails (e.g. rate limit / TooManyRequests / usage \
+limit), do NOT draw a fallback with Pillow, PIL, ImageMagick, matplotlib or any \
+code-drawn placeholder; report the failure explicitly instead."
 ```
 
+- Do **not** tell Codex to "save to `${RESOLVED}`": `image_gen` always writes to
+  its own `~/.codex/generated_images/<session>/` dir and ignores a target path,
+  so that instruction only confuses the agent. This workflow copies the result to
+  `${RESOLVED}` itself in Step 3.5.
 - The user prompt becomes plain text **inside** Codex's instruction; it never
   reaches the host shell as code. Passing `"$FULL_PROMPT"` as one quoted arg is
   what neutralises shell metacharacters.
 - The CLI query to Codex is in English (per cli-language policy).
 
-### Step 3 — Generate the image (single attempt, sandbox off for THIS command only)
+### Step 3 — Generate the image (single attempt, layer-1 sandbox off for THIS command only)
 
 Run exactly once (do NOT loop — repeated calls trigger rate limits). This is the
-only command that uses `dangerouslyDisableSandbox: true`; set Bash `timeout` to `180000`:
+only command that uses `dangerouslyDisableSandbox: true` (layer 1); Codex's own
+sandbox (layer 2) stays `workspace-write` per the Sandbox Policy. Set Bash
+`timeout` to `180000`.
+
+First record a freshness marker, then run Codex in the **same** command so the
+marker's timestamp precedes generation. Step 3.5 runs as a **separate** Bash call
+and shell variables do not persist between calls, so the marker path must be a
+fixed literal you reuse verbatim in both steps. Make it **unique per run**: pick
+one `RUN_ID` token (e.g. a timestamp plus a few random chars) and hard-code the
+**same** resulting path string in Step 3 and Step 3.5, so two concurrent
+generations never share a marker. Do NOT use `$$`/`$RANDOM` inline — they differ
+between the two separate Bash calls.
 
 ```bash
+MARKER="${TMPDIR:-/tmp}/imggen.<RUN_ID>.marker"   # e.g. .../imggen.20260617-0930-a1b2.marker
+touch "$MARKER"
+sleep 1  # ensure any new image has a strictly newer mtime than the marker
+
 codex exec \
   --model "$IMAGE_MODEL" \
   --sandbox workspace-write \
+  -c sandbox_workspace_write.network_access=true \
+  -c model_reasoning_effort=low \
   --skip-git-repo-check \
-  --full-auto \
   "$FULL_PROMPT" < /dev/null
 ```
+
+Notes:
+
+- `-c sandbox_workspace_write.network_access=true` opens network while keeping the
+  filesystem confined to the repo (see Sandbox Policy). Required for codex
+  0.140.0's `image_gen` app-server.
+- `-c model_reasoning_effort=low` keeps the agent from over-thinking and
+  self-rejecting/regenerating the output (and cuts token cost). Do not raise it.
+- `--full-auto` is **removed** — it is deprecated in codex 0.140.0 (folded into
+  `--sandbox`). Do not re-add it.
+
+### Step 3.5 — Locate the fresh output and copy it to `$RESOLVED` (freshness guard)
+
+`image_gen` saves to `~/.codex/generated_images/<session>/ig_*.png`, NOT to
+`$RESOLVED`. Find the newest `ig_*.png` that is **strictly newer than the Step 3
+marker** and copy it. The marker check is the freshness guard: it prevents picking
+up a **stale image from a previous run** (which would otherwise be reported as a
+false success). Re-use the **same** `RUN_ID` marker literal as Step 3 (a separate
+Bash call does not inherit Step 3's `$MARKER` variable). Run under the normal
+sandbox:
+
+```bash
+MARKER="${TMPDIR:-/tmp}/imggen.<RUN_ID>.marker"   # SAME literal as Step 3
+GEN_DIR="$HOME/.codex/generated_images"
+
+# Newest ig_*.png strictly newer than the marker. NUL-delimited read + `-nt` so
+# the result is empty when nothing new was produced, and it is safe for any
+# filename. Do NOT pipe to `xargs ls`: with no input, BSD xargs runs `ls` against
+# the CWD and yields a bogus match that defeats the freshness guard. Avoid GNU-only
+# flags (`find -printf`, `stat -c`, `xargs -r`) — this must work on macOS too.
+FRESH=""
+if [ -d "$GEN_DIR" ]; then
+  while IFS= read -r -d '' f; do
+    if [ -z "$FRESH" ] || [ "$f" -nt "$FRESH" ]; then FRESH="$f"; fi
+  done < <(find "$GEN_DIR" -type f -name 'ig_*.png' -newer "$MARKER" -print0 2>/dev/null)
+fi
+rm -f "$MARKER"
+
+if [ -z "$FRESH" ]; then
+  echo "ERROR: no image newer than the marker was produced (generation failed; \
+NOT falling back to any older image)."
+  # Treat as FAILURE — do NOT copy or accept any pre-existing file.
+  exit 1
+fi
+
+cp "$FRESH" "$RESOLVED" || { echo "ERROR: failed to copy $FRESH -> $RESOLVED"; exit 1; }
+echo "COPIED: $FRESH -> $RESOLVED"
+```
+
+If no fresh file exists, generation did not produce a new image (rate/usage
+limit, app-server error, or self-rejection): report FAILURE honestly. Never copy
+an older file — that is exactly the stale-image bug this guard prevents.
 
 ### Step 4 — Verify it is a real AI image (placeholder = failure)
 

--- a/.claude/agents/image-generator.md
+++ b/.claude/agents/image-generator.md
@@ -61,7 +61,9 @@ wording.
     network it fails app-server init with `Operation not permitted`.
   - The image itself is saved by Codex's own process (not a model-generated shell
     command) to `~/.codex/generated_images/<session>/`, so it is unaffected by
-    the workspace-write filesystem restriction.
+    the workspace-write filesystem restriction — **provided `--enable imagegenext`
+    is set** (Step 3). Without that flag, codex 0.140.0's exec mode does not write
+    the file to disk at all.
   - **NEVER** use `--sandbox danger-full-access` or
     `--dangerously-bypass-approvals-and-sandbox` here. They remove the
     filesystem boundary (whole-disk read/write/delete) and were explicitly
@@ -155,6 +157,7 @@ codex exec \
   --model "$IMAGE_MODEL" \
   --sandbox workspace-write \
   -c sandbox_workspace_write.network_access=true \
+  --enable imagegenext \
   -c model_reasoning_effort=low \
   --skip-git-repo-check \
   "$FULL_PROMPT" < /dev/null
@@ -162,38 +165,49 @@ codex exec \
 
 Notes:
 
+- `--enable imagegenext` is **required** on codex 0.140.0. Without it, `codex exec`
+  generates the image but **does NOT persist it to disk** (the built-in `image_gen`
+  result is only returned inline in the event stream; `~/.codex/generated_images/`
+  stays empty and `saved_path` is never populated). This is a regression vs codex
+  0.137.0, where exec saved the file by default. With `imagegenext` enabled, codex
+  writes the image to `~/.codex/generated_images/<session>/call_*.png` again.
 - `-c sandbox_workspace_write.network_access=true` opens network while keeping the
   filesystem confined to the repo (see Sandbox Policy). Required for codex
   0.140.0's `image_gen` app-server.
 - `-c model_reasoning_effort=low` keeps the agent from over-thinking and
-  self-rejecting/regenerating the output (and cuts token cost). Do not raise it.
+  self-rejecting/regenerating the output (and cuts token cost). Do not raise it —
+  at default effort the agent loops for many minutes and never finishes.
 - `--full-auto` is **removed** — it is deprecated in codex 0.140.0 (folded into
   `--sandbox`). Do not re-add it.
 
 ### Step 3.5 — Locate the fresh output and copy it to `$RESOLVED` (freshness guard)
 
-`image_gen` saves to `~/.codex/generated_images/<session>/ig_*.png`, NOT to
-`$RESOLVED`. Find the newest `ig_*.png` that is **strictly newer than the Step 3
-marker** and copy it. The marker check is the freshness guard: it prevents picking
-up a **stale image from a previous run** (which would otherwise be reported as a
-false success). Re-use the **same** `RUN_ID` marker literal as Step 3 (a separate
-Bash call does not inherit Step 3's `$MARKER` variable). Run under the normal
-sandbox:
+With `imagegenext` enabled (Step 3), `image_gen` saves to
+`~/.codex/generated_images/<session>/call_*.png` (older codex used `ig_*.png`), NOT
+to `$RESOLVED`. Find the newest generated PNG (`call_*.png` or `ig_*.png`) that is
+**strictly newer than the Step 3 marker** and copy it. The marker check is the
+freshness guard: it prevents picking up a **stale image from a previous run** (which
+would otherwise be reported as a false success — this is exactly what happens when
+the file is missing and the agent grabs an old one). Re-use the **same** `RUN_ID`
+marker literal as Step 3 (a separate Bash call does not inherit Step 3's `$MARKER`
+variable). Run under the normal sandbox:
 
 ```bash
 MARKER="${TMPDIR:-/tmp}/imggen.<RUN_ID>.marker"   # SAME literal as Step 3
 GEN_DIR="$HOME/.codex/generated_images"
 
-# Newest ig_*.png strictly newer than the marker. NUL-delimited read + `-nt` so
-# the result is empty when nothing new was produced, and it is safe for any
-# filename. Do NOT pipe to `xargs ls`: with no input, BSD xargs runs `ls` against
-# the CWD and yields a bogus match that defeats the freshness guard. Avoid GNU-only
-# flags (`find -printf`, `stat -c`, `xargs -r`) — this must work on macOS too.
+# Newest generated PNG strictly newer than the marker. Match BOTH naming schemes
+# (`call_*.png` on codex 0.140.0 + imagegenext, `ig_*.png` on older codex).
+# NUL-delimited read + `-nt` so the result is empty when nothing new was produced,
+# and it is safe for any filename. Do NOT pipe to `xargs ls`: with no input, BSD
+# xargs runs `ls` against the CWD and yields a bogus match that defeats the
+# freshness guard. Avoid GNU-only flags (`find -printf`, `stat -c`, `xargs -r`) —
+# this must work on macOS too.
 FRESH=""
 if [ -d "$GEN_DIR" ]; then
   while IFS= read -r -d '' f; do
     if [ -z "$FRESH" ] || [ "$f" -nt "$FRESH" ]; then FRESH="$f"; fi
-  done < <(find "$GEN_DIR" -type f -name 'ig_*.png' -newer "$MARKER" -print0 2>/dev/null)
+  done < <(find "$GEN_DIR" -type f \( -name 'call_*.png' -o -name 'ig_*.png' \) -newer "$MARKER" -print0 2>/dev/null)
 fi
 rm -f "$MARKER"
 
@@ -211,6 +225,14 @@ echo "COPIED: $FRESH -> $RESOLVED"
 If no fresh file exists, generation did not produce a new image (rate/usage
 limit, app-server error, or self-rejection): report FAILURE honestly. Never copy
 an older file — that is exactly the stale-image bug this guard prevents.
+
+**Do NOT improvise a recovery.** If `$FRESH` is empty you MUST stop and report
+FAILURE. Do NOT then browse `$GEN_DIR`, run `ls -t … | head`, pick "the newest
+file", or copy any file you locate by hand — those bypass the freshness guard and
+will silently grab a stale image from a previous run (observed false-success mode:
+the agent copied an unrelated older `call_*.png` and reported success). The ONLY
+file you may copy is the one the freshness-guarded `find` above selected. If the
+flag/glob seem wrong, report that — do not work around the guard.
 
 ### Step 4 — Verify it is a real AI image (placeholder = failure)
 

--- a/.claude/skills/image-gen/SKILL.md
+++ b/.claude/skills/image-gen/SKILL.md
@@ -128,6 +128,9 @@ Task(subagent_type="image-generator", prompt="""
 - **モデル**: 既定 `gpt-5.5`（`gpt-5.3-codex` 等のコーディングモデルは image_gen 非対応）。
   変更は `image-generation` パッケージ config（`config/image-generation.yaml` の `image_model`）で行う。
 - **sandbox**: 画像生成コマンドのみ Claude Code 側 Bash を `dangerouslyDisableSandbox: true` で実行する
-  （Codex の app-server 起動が層1 sandbox に阻害されるため）。Codex 側は通常の `workspace-write`。
+  （Codex の app-server 起動が層1 sandbox に阻害されるため）。Codex 側（層2）は
+  `workspace-write` のまま（FS は repo 内に OS 強制で限定）、`image_gen` の backend 通信のため
+  `network_access=true` だけを開放する。`danger-full-access` は使わない（詳細は image-generator
+  エージェント定義の Sandbox Policy）。
 - **レートリミット**: 連打で発生する。1 リクエストにつき 1 回だけ生成を試みる。
 - **出力先**: デフォルト `generated-images/` は `.gitignore` 管理。成果物はユーザーが目視確認する前提。

--- a/.claude/skills/image-gen/SKILL.md
+++ b/.claude/skills/image-gen/SKILL.md
@@ -132,5 +132,8 @@ Task(subagent_type="image-generator", prompt="""
   `workspace-write` のまま（FS は repo 内に OS 強制で限定）、`image_gen` の backend 通信のため
   `network_access=true` だけを開放する。`danger-full-access` は使わない（詳細は image-generator
   エージェント定義の Sandbox Policy）。
+- **`--enable imagegenext` 必須**（codex 0.140.0）: これが無いと exec モードで生成画像が
+  ディスク保存されず（`saved_path` 未populate）、結果を取得できない。0.137.0 からの回帰。
+  詳細は image-generator エージェント定義の Step 3。
 - **レートリミット**: 連打で発生する。1 リクエストにつき 1 回だけ生成を試みる。
 - **出力先**: デフォルト `generated-images/` は `.gitignore` 管理。成果物はユーザーが目視確認する前提。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`/image-gen` スキルの画像生成失敗を修正（codex 0.140.0 対応）**: codex-cli 0.140.0 への更新で `image-generator` エージェントの呼び出し契約が壊れていた問題を修正。実機検証で 3 つの原因を特定し対処した
+  - **sandbox レベル回帰**: `--sandbox workspace-write` だけでは `image_gen` の in-process app-server が `failed to initialize in-process app-server client: Operation not permitted` で起動しなくなった（backend 通信に network が必要）。`-c sandbox_workspace_write.network_access=true` で **network のみ開放**し、ファイルシステムは `workspace-write`（repo 内に OS 強制で限定）のまま維持。`danger-full-access` は untrusted prompt 経由の悪用を避けるため**採用しない**
+  - **`--full-auto` 廃止**: codex 0.140.0 で deprecated（`--sandbox` に統合）のためコマンドから削除
+  - **保存先の取りこぼし + 鮮度ガード追加**: `image_gen` は指定パスではなく常に `~/.codex/generated_images/<session>/ig_*.png` に保存する。生成直前のマーカー時刻より**新しい**ファイルのみを採用して出力先へコピーする Step を追加。過去の画像を誤って成功扱いする不具合（stale image）を防止
+  - 併せて `-c model_reasoning_effort=low` を指定し、agentic な Codex が生成画像を自己評価で破棄する挙動とトークン浪費を抑制
+  - 設計改訂は ADR-20260605-023 の Update（2026-06-17）に記録
+
 ### Added
 
 - `packages/fail-logs`: AI の失敗イベントを記録する基盤パッケージ（`core` のみ依存）。PostToolUse hook（`capture-failures.py`）がツール実行エラー・テスト/lint 失敗・外部 CLI 失敗を検知し、**失敗のみ**を `.claude/logs/fail-logs/failures.jsonl`（audit v1 互換スキーマ・所有者限定 `0600`・機密マスク済み）に追記する。「失敗を蓄積して次回以降に活かす」学習ループの記録基盤（活用は次フェーズ）

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
-- **`/image-gen` スキルの画像生成失敗を修正（codex 0.140.0 対応）**: codex-cli 0.140.0 への更新で `image-generator` エージェントの呼び出し契約が壊れていた問題を修正。実機検証で 3 つの原因を特定し対処した
-  - **sandbox レベル回帰**: `--sandbox workspace-write` だけでは `image_gen` の in-process app-server が `failed to initialize in-process app-server client: Operation not permitted` で起動しなくなった（backend 通信に network が必要）。`-c sandbox_workspace_write.network_access=true` で **network のみ開放**し、ファイルシステムは `workspace-write`（repo 内に OS 強制で限定）のまま維持。`danger-full-access` は untrusted prompt 経由の悪用を避けるため**採用しない**
-  - **`--full-auto` 廃止**: codex 0.140.0 で deprecated（`--sandbox` に統合）のためコマンドから削除
-  - **保存先の取りこぼし + 鮮度ガード追加**: `image_gen` は指定パスではなく常に `~/.codex/generated_images/<session>/ig_*.png` に保存する。生成直前のマーカー時刻より**新しい**ファイルのみを採用して出力先へコピーする Step を追加。過去の画像を誤って成功扱いする不具合（stale image）を防止
-  - 併せて `-c model_reasoning_effort=low` を指定し、agentic な Codex が生成画像を自己評価で破棄する挙動とトークン浪費を抑制
+- **`/image-gen` スキルの画像生成失敗を修正（codex 0.140.0 対応・実機 E2E 検証済）**: codex-cli 0.140.0 への更新で `image-generator` エージェントの呼び出し契約が壊れていた問題を修正。実機の生成検証で原因を特定し対処した（赤リンゴ画像の出力まで確認）
+  - **保存回帰の解決（`--enable imagegenext` 必須）**: codex 0.140.0 の `exec` モードは built-in `image_gen` の画像を**ディスクに保存しなくなっていた**（`image_generation_end` イベントから `saved_path` キーが消失。画像は base64 で返るのみ）。0.137.0 からの回帰で、`--enable imagegenext` フラグを付けると保存が復活する。これが無いと `~/.codex/generated_images/` は空のままで、エージェントが過去の画像を誤って掴む（虚偽成功）原因になっていた
+  - **保存ファイル名の変化に追従**: imagegenext 有効時の保存名は `ig_*.png` ではなく `call_*.png`。鮮度ガードの検索を両パターン対応（`\( -name 'call_*.png' -o -name 'ig_*.png' \)`）に更新
+  - **鮮度ガードの手動迂回を明示的に禁止**: 鮮度判定で対象なしのとき `ls -t | head` 等で session ディレクトリを漁って「最新ファイル」を掴む improvise を禁止（無関係な古い画像を誤コピーして虚偽成功する実害を確認）。対象なしは必ず FAILURE 報告
+  - **sandbox レベル回帰**: `--sandbox workspace-write` だけでは `image_gen` の in-process app-server が `Operation not permitted` で起動しない（backend 通信に network が必要）。`-c sandbox_workspace_write.network_access=true` で **network のみ開放**し、FS は `workspace-write`（repo 内に OS 強制で限定）のまま維持。`danger-full-access` は untrusted prompt 経由の悪用を避けるため**採用しない**
+  - **`--full-auto` 廃止**: codex 0.140.0 で deprecated（`--sandbox` に統合）のためコマンドから削除。併せて `-c model_reasoning_effort=low` を指定（default effort は自己評価ループで長時間ハングするため必須）
   - 設計改訂は ADR-20260605-023 の Update（2026-06-17）に記録
 
 ### Added

--- a/docs/adr/ADR-20260605-023.md
+++ b/docs/adr/ADR-20260605-023.md
@@ -114,10 +114,18 @@ codex-cli が **0.140.0** に更新され、上記「確定した呼び出し契
 
 1. **`--sandbox workspace-write` だけでは app-server が起動しない**。`image_gen` の in-process app-server が backend へ通信するため、Codex 層2 の **network が遮断**されていると `failed to initialize in-process app-server client: Operation not permitted (os error 1)` で失敗する。→ `-c sandbox_workspace_write.network_access=true` で **network だけ開放**する。FS は `workspace-write` のまま repo 内に OS 強制で限定され、`danger-full-access` / `--dangerously-bypass-approvals-and-sandbox` は**使わない**（untrusted prompt で呼ばれ得るため OS 境界を維持）。
 2. **`--full-auto` は deprecated**（`--sandbox` に統合）。削除する。
-3. **保存先は指定パスに従わない**。`image_gen` は常に `~/.codex/generated_images/<session>/ig_*.png` に保存する（プロンプトの "Save to `<path>`" は無視）。エージェントは**生成直前のマーカー時刻より新しい**ファイルのみを採用し出力先へコピーする（**鮮度ガード**: 過去の画像を誤って成功扱いする不具合を防ぐ）。
-4. **agentic codex の自己検閲**。高い reasoning では Codex が生成画像を品質評価して勝手に破棄することがある。`-c model_reasoning_effort=low` で抑制し、プロンプトで「品質で拒否するな/削除するな」を明示する。
+3. **保存先は指定パスに従わない**。`image_gen` は常に `~/.codex/generated_images/<session>/` に保存する（プロンプトの "Save to `<path>`" は無視）。エージェントは**生成直前のマーカー時刻より新しい**ファイルのみを採用し出力先へコピーする（**鮮度ガード**: 過去の画像を誤って成功扱いする不具合を防ぐ）。
+4. **agentic codex の自己検閲**。高い reasoning では Codex が生成画像を品質評価して勝手に破棄することがある。`-c model_reasoning_effort=low` で抑制し、プロンプトで「品質で拒否するな/削除するな」を明示する（default effort は自己評価ループで長時間ハングする）。
 
-改訂後の呼び出し契約:
+### 再改訂（2026-06-17 #2）: exec 保存回帰と `--enable imagegenext`
+
+上記改訂後も `/image-gen` が動かなかったため、実機の生成検証で根本原因を再特定した（エンドツーエンドで赤リンゴ出力まで確認）:
+
+5. **codex 0.140.0 の `exec` は built-in `image_gen` をディスク保存しない（0.137.0 からの回帰）**。`image_generation_end` イベントから `saved_path` キーが消え、画像は base64（`result`）で返るのみ。`~/.codex/generated_images/` は空のまま。→ **`--enable imagegenext` を付けると保存が復活**する（0.137.0 では default で保存していた）。`writable_roots` 追加では解決しない（seatbelt ではなく core 挙動）。
+6. **保存名が `ig_*.png` → `call_*.png` に変化**（imagegenext）。鮮度ガードの `find` は両パターンを対象にする。
+7. **鮮度ガードの手動迂回を禁止**。対象なし時に `ls -t | head` 等で session dir を漁って「最新ファイル」を掴むと、無関係な古い画像を誤コピーして虚偽成功する（実害を確認）。対象なしは必ず FAILURE 報告。
+
+再改訂後の呼び出し契約:
 
 ```bash
 # Claude Code 側 Bash は dangerouslyDisableSandbox: true で実行（層1 無効化）
@@ -125,11 +133,15 @@ codex exec \
   --model gpt-5.5 \
   --sandbox workspace-write \
   -c sandbox_workspace_write.network_access=true \
+  --enable imagegenext \
   -c model_reasoning_effort=low \
   --skip-git-repo-check \
   "Use your built-in image_gen tool to generate <subject>. Accept whatever it returns; \
    do NOT delete files. Print the saved path. Do NOT fall back to Pillow/ImageMagick on \
    rate limit; report failure explicitly." < /dev/null
+# 生成後: ~/.codex/generated_images/<session>/ で marker より新しい call_*.png|ig_*.png を出力先へコピー
 ```
+
+> **運用注意**: サブエージェント定義はセッション開始時スナップショットから読まれるため、`image-generator.md` を編集しても同一セッション内の Task 実行には反映されない。検証は新セッション、または Step 3〜4 を直接シェルで再現して行う。
 
 詳細は `packages/image-generation/agents/image-generator.md` の Sandbox Policy / Step 3 / Step 3.5 を正本とする。

--- a/docs/adr/ADR-20260605-023.md
+++ b/docs/adr/ADR-20260605-023.md
@@ -107,3 +107,29 @@ codex exec \
 - **レートリミット**: 連打で発生。1 タスク 1 回で緩和。検知時はユーザーに報告。
 - **Pillow フォールバック混入**: プロンプト禁止指示 + 出力検知の二段で防ぐが、検知漏れの可能性はゼロではない。生成後にユーザーが目視確認することを推奨。
 - **`dangerouslyDisableSandbox` の常用**: 画像生成コマンドに限定し、汎用化しない。セキュリティレビューで限定範囲を確認する。
+
+## Update（2026-06-17）: codex 0.140.0 での呼び出し契約の改訂
+
+codex-cli が **0.140.0** に更新され、上記「確定した呼び出し契約」が機能しなくなったため改訂する（原契約は履歴として残す）。実機検証（task/image-gen-bug）で確定した事実:
+
+1. **`--sandbox workspace-write` だけでは app-server が起動しない**。`image_gen` の in-process app-server が backend へ通信するため、Codex 層2 の **network が遮断**されていると `failed to initialize in-process app-server client: Operation not permitted (os error 1)` で失敗する。→ `-c sandbox_workspace_write.network_access=true` で **network だけ開放**する。FS は `workspace-write` のまま repo 内に OS 強制で限定され、`danger-full-access` / `--dangerously-bypass-approvals-and-sandbox` は**使わない**（untrusted prompt で呼ばれ得るため OS 境界を維持）。
+2. **`--full-auto` は deprecated**（`--sandbox` に統合）。削除する。
+3. **保存先は指定パスに従わない**。`image_gen` は常に `~/.codex/generated_images/<session>/ig_*.png` に保存する（プロンプトの "Save to `<path>`" は無視）。エージェントは**生成直前のマーカー時刻より新しい**ファイルのみを採用し出力先へコピーする（**鮮度ガード**: 過去の画像を誤って成功扱いする不具合を防ぐ）。
+4. **agentic codex の自己検閲**。高い reasoning では Codex が生成画像を品質評価して勝手に破棄することがある。`-c model_reasoning_effort=low` で抑制し、プロンプトで「品質で拒否するな/削除するな」を明示する。
+
+改訂後の呼び出し契約:
+
+```bash
+# Claude Code 側 Bash は dangerouslyDisableSandbox: true で実行（層1 無効化）
+codex exec \
+  --model gpt-5.5 \
+  --sandbox workspace-write \
+  -c sandbox_workspace_write.network_access=true \
+  -c model_reasoning_effort=low \
+  --skip-git-repo-check \
+  "Use your built-in image_gen tool to generate <subject>. Accept whatever it returns; \
+   do NOT delete files. Print the saved path. Do NOT fall back to Pillow/ImageMagick on \
+   rate limit; report failure explicitly." < /dev/null
+```
+
+詳細は `packages/image-generation/agents/image-generator.md` の Sandbox Policy / Step 3 / Step 3.5 を正本とする。

--- a/facets/instructions/image-gen.md
+++ b/facets/instructions/image-gen.md
@@ -69,6 +69,9 @@ Task(subagent_type="image-generator", prompt="""
 - **モデル**: 既定 `gpt-5.5`（`gpt-5.3-codex` 等のコーディングモデルは image_gen 非対応）。
   変更は `image-generation` パッケージ config（`config/image-generation.yaml` の `image_model`）で行う。
 - **sandbox**: 画像生成コマンドのみ Claude Code 側 Bash を `dangerouslyDisableSandbox: true` で実行する
-  （Codex の app-server 起動が層1 sandbox に阻害されるため）。Codex 側は通常の `workspace-write`。
+  （Codex の app-server 起動が層1 sandbox に阻害されるため）。Codex 側（層2）は
+  `workspace-write` のまま（FS は repo 内に OS 強制で限定）、`image_gen` の backend 通信のため
+  `network_access=true` だけを開放する。`danger-full-access` は使わない（詳細は image-generator
+  エージェント定義の Sandbox Policy）。
 - **レートリミット**: 連打で発生する。1 リクエストにつき 1 回だけ生成を試みる。
 - **出力先**: デフォルト `generated-images/` は `.gitignore` 管理。成果物はユーザーが目視確認する前提。

--- a/facets/instructions/image-gen.md
+++ b/facets/instructions/image-gen.md
@@ -73,5 +73,8 @@ Task(subagent_type="image-generator", prompt="""
   `workspace-write` のまま（FS は repo 内に OS 強制で限定）、`image_gen` の backend 通信のため
   `network_access=true` だけを開放する。`danger-full-access` は使わない（詳細は image-generator
   エージェント定義の Sandbox Policy）。
+- **`--enable imagegenext` 必須**（codex 0.140.0）: これが無いと exec モードで生成画像が
+  ディスク保存されず（`saved_path` 未populate）、結果を取得できない。0.137.0 からの回帰。
+  詳細は image-generator エージェント定義の Step 3。
 - **レートリミット**: 連打で発生する。1 リクエストにつき 1 回だけ生成を試みる。
 - **出力先**: デフォルト `generated-images/` は `.gitignore` 管理。成果物はユーザーが目視確認する前提。

--- a/packages/image-generation/README.md
+++ b/packages/image-generation/README.md
@@ -47,6 +47,7 @@ Codex の組み込み `image_gen` は ChatGPT 認証で動くため **`OPENAI_AP
 codex exec --model gpt-5.5 \
   --sandbox workspace-write \
   -c sandbox_workspace_write.network_access=true \
+  --enable imagegenext \
   -c model_reasoning_effort=low \
   --skip-git-repo-check \
   "Use your built-in image_gen tool to generate <subject>. Accept whatever it returns; \
@@ -54,14 +55,18 @@ codex exec --model gpt-5.5 \
    rate limit; report failure explicitly." < /dev/null
 ```
 
+- **`--enable imagegenext` が必須**: codex 0.140.0 の `exec` は、このフラグが無いと
+  `image_gen` の画像を**ディスクに保存しない**（`saved_path` が返らず base64 のみ）。
+  0.137.0 からの回帰で、`imagegenext` を有効化すると保存が復活する。
 - **`network_access=true` が必須**: codex 0.140.0 では `image_gen` の app-server が
   backend 通信を行うため、network 遮断のままだと app-server が `Operation not permitted`
   で起動しない。FS は `workspace-write` のまま repo 内に限定され、`danger-full-access`
   は使わない（OS 強制の境界を維持）。
 - **`--full-auto` は廃止**: codex 0.140.0 で deprecated（`--sandbox` に統合）。
-- **保存先**: `image_gen` は常に `~/.codex/generated_images/<session>/ig_*.png` に保存する。
-  エージェントは生成直前のマーカー時刻より**新しい**ファイルだけを採用して出力先へコピーする
-  （古い画像を誤って成功扱いしない鮮度ガード）。
+- **保存先**: `image_gen` は `~/.codex/generated_images/<session>/` に保存する（imagegenext 有効時の
+  ファイル名は `call_*.png`、旧 codex は `ig_*.png`）。エージェントは生成直前のマーカー時刻より
+  **新しい**ファイルだけを採用して出力先へコピーする（古い画像を誤って成功扱いしない鮮度ガード）。
+  対象なし時に手動でディレクトリを漁って最新ファイルを掴むのは**禁止**（虚偽成功の原因）。
 - モデルは既定 `gpt-5.5`（`gpt-5.3-codex` 等のコーディングモデルは image_gen 非対応）。
   `config/image-generation.yaml` の `image_model` で差し替え可能。
 - レートリミット/利用上限は連打由来。**1 タスク 1 回**で回避する。

--- a/packages/image-generation/README.md
+++ b/packages/image-generation/README.md
@@ -36,22 +36,35 @@ description に基づく Claude Code のネイティブ subagent dispatch で起
 Codex の組み込み `image_gen` は ChatGPT 認証で動くため **`OPENAI_API_KEY` は不要**。
 非対話 `codex exec` から呼ぶには **sandbox の二層構造**を解く必要がある。
 
-| 層  | 対象                        | 設定                                            |
-| --- | --------------------------- | ----------------------------------------------- |
-| 層1 | Claude Code の Bash sandbox | **無効化**（`dangerouslyDisableSandbox: true`） |
-| 層2 | Codex の `--sandbox`        | 通常の `workspace-write`（危険フラグ不要）      |
+| 層  | 対象                        | 設定                                                                       |
+| --- | --------------------------- | -------------------------------------------------------------------------- |
+| 層1 | Claude Code の Bash sandbox | **無効化**（`dangerouslyDisableSandbox: true`）                            |
+| 層2 | Codex の `--sandbox`        | `workspace-write` + `network_access=true`（FS は repo 内に OS 強制で限定） |
 
-確定呼び出し:
+確定呼び出し（codex 0.140.0）:
 
 ```bash
-codex exec --model gpt-5.5 --sandbox workspace-write --skip-git-repo-check --full-auto \
-  "Generate <subject>. Save the file to <abs-path>. Use your built-in image generation tool. \
-   Do NOT fall back to Pillow/ImageMagick on rate limit; report failure explicitly." < /dev/null
+codex exec --model gpt-5.5 \
+  --sandbox workspace-write \
+  -c sandbox_workspace_write.network_access=true \
+  -c model_reasoning_effort=low \
+  --skip-git-repo-check \
+  "Use your built-in image_gen tool to generate <subject>. Accept whatever it returns; \
+   do NOT delete files. Print the saved path. Do NOT fall back to Pillow/ImageMagick on \
+   rate limit; report failure explicitly." < /dev/null
 ```
 
+- **`network_access=true` が必須**: codex 0.140.0 では `image_gen` の app-server が
+  backend 通信を行うため、network 遮断のままだと app-server が `Operation not permitted`
+  で起動しない。FS は `workspace-write` のまま repo 内に限定され、`danger-full-access`
+  は使わない（OS 強制の境界を維持）。
+- **`--full-auto` は廃止**: codex 0.140.0 で deprecated（`--sandbox` に統合）。
+- **保存先**: `image_gen` は常に `~/.codex/generated_images/<session>/ig_*.png` に保存する。
+  エージェントは生成直前のマーカー時刻より**新しい**ファイルだけを採用して出力先へコピーする
+  （古い画像を誤って成功扱いしない鮮度ガード）。
 - モデルは既定 `gpt-5.5`（`gpt-5.3-codex` 等のコーディングモデルは image_gen 非対応）。
   `config/image-generation.yaml` の `image_model` で差し替え可能。
-- レートリミットは連打由来。**1 タスク 1 回**で回避する。
+- レートリミット/利用上限は連打由来。**1 タスク 1 回**で回避する。
 - レートリミット時に Codex が Pillow で描く代替画像（非 AI）は**検知して失敗扱い**にする。
 
 ## 出力先

--- a/packages/image-generation/agents/image-generator.md
+++ b/packages/image-generation/agents/image-generator.md
@@ -31,23 +31,47 @@ and stop (do NOT draw a placeholder yourself).
 
 Do NOT hardcode values that exist in the config; always read them first.
 
-## Sandbox Policy (IMPORTANT — intentional exception)
+## Sandbox Policy (IMPORTANT — two layers, read carefully)
 
 This agent is the **single** deliberate exception to the project-wide rule
 "`dangerouslyDisableSandbox` is never used". The exception lives here and nowhere
 else — callers (skills/orchestrator) must NOT pass sandbox instructions to this
 agent; this Sandbox Policy is the only authority.
 
-- The image generation Bash command (Step 3 only) **MUST** run with
-  `dangerouslyDisableSandbox: true`.
+There are two independent sandbox layers around the `codex exec` call. The
+security boundary is **layer 2** (Codex's own OS-enforced seatbelt), NOT prompt
+wording.
+
+- **Layer 1 — Claude Code Bash sandbox**: the image generation Bash command
+  (Step 3 only) **MUST** run with `dangerouslyDisableSandbox: true`.
   Reason: Codex spins up an in-process app-server to call `image_gen`, and the
-  Claude Code Bash sandbox (layer 1) blocks that with `Operation not permitted`.
-- Codex's own sandbox (layer 2) stays at the normal `--sandbox workspace-write`.
-  The dangerous Codex flag `--dangerously-bypass-approvals-and-sandbox` is **NOT** used.
-- Every other Bash command in this workflow (path validation, file inspection)
-  runs under the **normal sandbox**. Only the one `codex exec` line is exempt.
-- Because layer 1 is off for that one command, input validation (Steps 1–2) is a
-  hard security boundary, not a nicety. Do not skip it.
+  Claude Code Bash sandbox blocks that process/socket spawn with
+  `Operation not permitted`. Every other Bash command in this workflow (path
+  validation, file inspection, copy) runs under the **normal sandbox**. Only the
+  one `codex exec` line is exempt.
+- **Layer 2 — Codex's own sandbox**: stays at `--sandbox workspace-write` **with
+  network access enabled** via `-c sandbox_workspace_write.network_access=true`.
+  - `workspace-write` keeps the filesystem **OS-restricted to the repo + /tmp**:
+    Codex cannot read, write, or delete anything outside the workspace (e.g.
+    `~/.ssh`, repo-external `.env`, other projects) regardless of what the
+    (untrusted) prompt says. This is a deterministic, kernel-enforced boundary —
+    do NOT weaken it.
+  - `network_access=true` is required because codex 0.140.0's `image_gen`
+    app-server reaches its backend over the network; with the default restricted
+    network it fails app-server init with `Operation not permitted`.
+  - The image itself is saved by Codex's own process (not a model-generated shell
+    command) to `~/.codex/generated_images/<session>/`, so it is unaffected by
+    the workspace-write filesystem restriction.
+  - **NEVER** use `--sandbox danger-full-access` or
+    `--dangerously-bypass-approvals-and-sandbox` here. They remove the
+    filesystem boundary (whole-disk read/write/delete) and were explicitly
+    rejected: the agent could be invoked with an untrusted prompt, so the OS
+    boundary must remain.
+- **Residual risk** (accepted): with network open and repo files readable, repo
+  contents could in principle be exfiltrated. Input validation (Steps 1–2) and
+  the constrained Codex prompt (Step 2) are defense-in-depth on top of the OS
+  boundary — keep them. Do not feed this agent prompts from fully untrusted
+  automated sources.
 
 ## Implementation Method (required)
 
@@ -86,31 +110,107 @@ PROMPT_TEXT=$(cat <<'PROMPT_EOF'
 PROMPT_EOF
 )
 # Build the instruction with parameter expansion (no eval, no nested quoting):
-FULL_PROMPT="Generate the following image: ${PROMPT_TEXT}. \
-Save the file to ${RESOLVED}. Use your built-in image generation tool. \
-IMPORTANT: if image generation fails (e.g. rate limit / TooManyRequests), do NOT \
-draw a fallback with Pillow, PIL, ImageMagick, matplotlib or any code-drawn \
-placeholder; report the failure explicitly instead."
+FULL_PROMPT="Use your built-in image_gen tool to generate the following image: \
+${PROMPT_TEXT}. \
+Accept whatever image_gen returns — do NOT judge, reject, or regenerate it for \
+quality, color, or composition reasons. Do NOT delete any generated file. \
+Do NOT read, write, or run anything unrelated to this single image generation. \
+After generation, print the absolute path of the image file image_gen saved on disk. \
+IMPORTANT: if image generation fails (e.g. rate limit / TooManyRequests / usage \
+limit), do NOT draw a fallback with Pillow, PIL, ImageMagick, matplotlib or any \
+code-drawn placeholder; report the failure explicitly instead."
 ```
 
+- Do **not** tell Codex to "save to `${RESOLVED}`": `image_gen` always writes to
+  its own `~/.codex/generated_images/<session>/` dir and ignores a target path,
+  so that instruction only confuses the agent. This workflow copies the result to
+  `${RESOLVED}` itself in Step 3.5.
 - The user prompt becomes plain text **inside** Codex's instruction; it never
   reaches the host shell as code. Passing `"$FULL_PROMPT"` as one quoted arg is
   what neutralises shell metacharacters.
 - The CLI query to Codex is in English (per cli-language policy).
 
-### Step 3 — Generate the image (single attempt, sandbox off for THIS command only)
+### Step 3 — Generate the image (single attempt, layer-1 sandbox off for THIS command only)
 
 Run exactly once (do NOT loop — repeated calls trigger rate limits). This is the
-only command that uses `dangerouslyDisableSandbox: true`; set Bash `timeout` to `180000`:
+only command that uses `dangerouslyDisableSandbox: true` (layer 1); Codex's own
+sandbox (layer 2) stays `workspace-write` per the Sandbox Policy. Set Bash
+`timeout` to `180000`.
+
+First record a freshness marker, then run Codex in the **same** command so the
+marker's timestamp precedes generation. Step 3.5 runs as a **separate** Bash call
+and shell variables do not persist between calls, so the marker path must be a
+fixed literal you reuse verbatim in both steps. Make it **unique per run**: pick
+one `RUN_ID` token (e.g. a timestamp plus a few random chars) and hard-code the
+**same** resulting path string in Step 3 and Step 3.5, so two concurrent
+generations never share a marker. Do NOT use `$$`/`$RANDOM` inline — they differ
+between the two separate Bash calls.
 
 ```bash
+MARKER="${TMPDIR:-/tmp}/imggen.<RUN_ID>.marker"   # e.g. .../imggen.20260617-0930-a1b2.marker
+touch "$MARKER"
+sleep 1  # ensure any new image has a strictly newer mtime than the marker
+
 codex exec \
   --model "$IMAGE_MODEL" \
   --sandbox workspace-write \
+  -c sandbox_workspace_write.network_access=true \
+  -c model_reasoning_effort=low \
   --skip-git-repo-check \
-  --full-auto \
   "$FULL_PROMPT" < /dev/null
 ```
+
+Notes:
+
+- `-c sandbox_workspace_write.network_access=true` opens network while keeping the
+  filesystem confined to the repo (see Sandbox Policy). Required for codex
+  0.140.0's `image_gen` app-server.
+- `-c model_reasoning_effort=low` keeps the agent from over-thinking and
+  self-rejecting/regenerating the output (and cuts token cost). Do not raise it.
+- `--full-auto` is **removed** — it is deprecated in codex 0.140.0 (folded into
+  `--sandbox`). Do not re-add it.
+
+### Step 3.5 — Locate the fresh output and copy it to `$RESOLVED` (freshness guard)
+
+`image_gen` saves to `~/.codex/generated_images/<session>/ig_*.png`, NOT to
+`$RESOLVED`. Find the newest `ig_*.png` that is **strictly newer than the Step 3
+marker** and copy it. The marker check is the freshness guard: it prevents picking
+up a **stale image from a previous run** (which would otherwise be reported as a
+false success). Re-use the **same** `RUN_ID` marker literal as Step 3 (a separate
+Bash call does not inherit Step 3's `$MARKER` variable). Run under the normal
+sandbox:
+
+```bash
+MARKER="${TMPDIR:-/tmp}/imggen.<RUN_ID>.marker"   # SAME literal as Step 3
+GEN_DIR="$HOME/.codex/generated_images"
+
+# Newest ig_*.png strictly newer than the marker. NUL-delimited read + `-nt` so
+# the result is empty when nothing new was produced, and it is safe for any
+# filename. Do NOT pipe to `xargs ls`: with no input, BSD xargs runs `ls` against
+# the CWD and yields a bogus match that defeats the freshness guard. Avoid GNU-only
+# flags (`find -printf`, `stat -c`, `xargs -r`) — this must work on macOS too.
+FRESH=""
+if [ -d "$GEN_DIR" ]; then
+  while IFS= read -r -d '' f; do
+    if [ -z "$FRESH" ] || [ "$f" -nt "$FRESH" ]; then FRESH="$f"; fi
+  done < <(find "$GEN_DIR" -type f -name 'ig_*.png' -newer "$MARKER" -print0 2>/dev/null)
+fi
+rm -f "$MARKER"
+
+if [ -z "$FRESH" ]; then
+  echo "ERROR: no image newer than the marker was produced (generation failed; \
+NOT falling back to any older image)."
+  # Treat as FAILURE — do NOT copy or accept any pre-existing file.
+  exit 1
+fi
+
+cp "$FRESH" "$RESOLVED" || { echo "ERROR: failed to copy $FRESH -> $RESOLVED"; exit 1; }
+echo "COPIED: $FRESH -> $RESOLVED"
+```
+
+If no fresh file exists, generation did not produce a new image (rate/usage
+limit, app-server error, or self-rejection): report FAILURE honestly. Never copy
+an older file — that is exactly the stale-image bug this guard prevents.
 
 ### Step 4 — Verify it is a real AI image (placeholder = failure)
 

--- a/packages/image-generation/agents/image-generator.md
+++ b/packages/image-generation/agents/image-generator.md
@@ -61,7 +61,9 @@ wording.
     network it fails app-server init with `Operation not permitted`.
   - The image itself is saved by Codex's own process (not a model-generated shell
     command) to `~/.codex/generated_images/<session>/`, so it is unaffected by
-    the workspace-write filesystem restriction.
+    the workspace-write filesystem restriction — **provided `--enable imagegenext`
+    is set** (Step 3). Without that flag, codex 0.140.0's exec mode does not write
+    the file to disk at all.
   - **NEVER** use `--sandbox danger-full-access` or
     `--dangerously-bypass-approvals-and-sandbox` here. They remove the
     filesystem boundary (whole-disk read/write/delete) and were explicitly
@@ -155,6 +157,7 @@ codex exec \
   --model "$IMAGE_MODEL" \
   --sandbox workspace-write \
   -c sandbox_workspace_write.network_access=true \
+  --enable imagegenext \
   -c model_reasoning_effort=low \
   --skip-git-repo-check \
   "$FULL_PROMPT" < /dev/null
@@ -162,38 +165,49 @@ codex exec \
 
 Notes:
 
+- `--enable imagegenext` is **required** on codex 0.140.0. Without it, `codex exec`
+  generates the image but **does NOT persist it to disk** (the built-in `image_gen`
+  result is only returned inline in the event stream; `~/.codex/generated_images/`
+  stays empty and `saved_path` is never populated). This is a regression vs codex
+  0.137.0, where exec saved the file by default. With `imagegenext` enabled, codex
+  writes the image to `~/.codex/generated_images/<session>/call_*.png` again.
 - `-c sandbox_workspace_write.network_access=true` opens network while keeping the
   filesystem confined to the repo (see Sandbox Policy). Required for codex
   0.140.0's `image_gen` app-server.
 - `-c model_reasoning_effort=low` keeps the agent from over-thinking and
-  self-rejecting/regenerating the output (and cuts token cost). Do not raise it.
+  self-rejecting/regenerating the output (and cuts token cost). Do not raise it —
+  at default effort the agent loops for many minutes and never finishes.
 - `--full-auto` is **removed** — it is deprecated in codex 0.140.0 (folded into
   `--sandbox`). Do not re-add it.
 
 ### Step 3.5 — Locate the fresh output and copy it to `$RESOLVED` (freshness guard)
 
-`image_gen` saves to `~/.codex/generated_images/<session>/ig_*.png`, NOT to
-`$RESOLVED`. Find the newest `ig_*.png` that is **strictly newer than the Step 3
-marker** and copy it. The marker check is the freshness guard: it prevents picking
-up a **stale image from a previous run** (which would otherwise be reported as a
-false success). Re-use the **same** `RUN_ID` marker literal as Step 3 (a separate
-Bash call does not inherit Step 3's `$MARKER` variable). Run under the normal
-sandbox:
+With `imagegenext` enabled (Step 3), `image_gen` saves to
+`~/.codex/generated_images/<session>/call_*.png` (older codex used `ig_*.png`), NOT
+to `$RESOLVED`. Find the newest generated PNG (`call_*.png` or `ig_*.png`) that is
+**strictly newer than the Step 3 marker** and copy it. The marker check is the
+freshness guard: it prevents picking up a **stale image from a previous run** (which
+would otherwise be reported as a false success — this is exactly what happens when
+the file is missing and the agent grabs an old one). Re-use the **same** `RUN_ID`
+marker literal as Step 3 (a separate Bash call does not inherit Step 3's `$MARKER`
+variable). Run under the normal sandbox:
 
 ```bash
 MARKER="${TMPDIR:-/tmp}/imggen.<RUN_ID>.marker"   # SAME literal as Step 3
 GEN_DIR="$HOME/.codex/generated_images"
 
-# Newest ig_*.png strictly newer than the marker. NUL-delimited read + `-nt` so
-# the result is empty when nothing new was produced, and it is safe for any
-# filename. Do NOT pipe to `xargs ls`: with no input, BSD xargs runs `ls` against
-# the CWD and yields a bogus match that defeats the freshness guard. Avoid GNU-only
-# flags (`find -printf`, `stat -c`, `xargs -r`) — this must work on macOS too.
+# Newest generated PNG strictly newer than the marker. Match BOTH naming schemes
+# (`call_*.png` on codex 0.140.0 + imagegenext, `ig_*.png` on older codex).
+# NUL-delimited read + `-nt` so the result is empty when nothing new was produced,
+# and it is safe for any filename. Do NOT pipe to `xargs ls`: with no input, BSD
+# xargs runs `ls` against the CWD and yields a bogus match that defeats the
+# freshness guard. Avoid GNU-only flags (`find -printf`, `stat -c`, `xargs -r`) —
+# this must work on macOS too.
 FRESH=""
 if [ -d "$GEN_DIR" ]; then
   while IFS= read -r -d '' f; do
     if [ -z "$FRESH" ] || [ "$f" -nt "$FRESH" ]; then FRESH="$f"; fi
-  done < <(find "$GEN_DIR" -type f -name 'ig_*.png' -newer "$MARKER" -print0 2>/dev/null)
+  done < <(find "$GEN_DIR" -type f \( -name 'call_*.png' -o -name 'ig_*.png' \) -newer "$MARKER" -print0 2>/dev/null)
 fi
 rm -f "$MARKER"
 
@@ -211,6 +225,14 @@ echo "COPIED: $FRESH -> $RESOLVED"
 If no fresh file exists, generation did not produce a new image (rate/usage
 limit, app-server error, or self-rejection): report FAILURE honestly. Never copy
 an older file — that is exactly the stale-image bug this guard prevents.
+
+**Do NOT improvise a recovery.** If `$FRESH` is empty you MUST stop and report
+FAILURE. Do NOT then browse `$GEN_DIR`, run `ls -t … | head`, pick "the newest
+file", or copy any file you locate by hand — those bypass the freshness guard and
+will silently grab a stale image from a previous run (observed false-success mode:
+the agent copied an unrelated older `call_*.png` and reported success). The ONLY
+file you may copy is the one the freshness-guarded `find` above selected. If the
+flag/glob seem wrong, report that — do not work around the guard.
 
 ### Step 4 — Verify it is a real AI image (placeholder = failure)
 


### PR DESCRIPTION
## 概要

codex-cli が **0.140.0** に更新され、`image-generator` エージェントの呼び出し契約が壊れて `/image-gen` が画像を生成できなくなっていた問題を修正します。実機検証で根本原因を特定しました。

## 根本原因と対処

| 原因 | 対処 |
|---|---|
| **sandbox 回帰**: `--sandbox workspace-write` だけでは `image_gen` の in-process app-server が `Operation not permitted` で起動しない（backend 通信に network が必要） | `-c sandbox_workspace_write.network_access=true` で **network のみ開放**。FS は `workspace-write` のまま repo 内に OS 強制で限定 |
| **`--full-auto` 廃止** (0.140.0 で deprecated) | コマンドから削除 |
| **保存先の取りこぼし**: `image_gen` は指定パスでなく常に `~/.codex/generated_images/<session>/ig_*.png` に保存 | 生成直前のマーカーより**新しい** `ig_*.png` のみ採用し出力先へコピーする Step 3.5 を追加（**鮮度ガード**＝stale image 誤採用を防止） |
| **agentic codex の自己検閲**（生成画像を勝手に破棄） | `-c model_reasoning_effort=low` ＋プロンプト明示 |

**`danger-full-access` は不採用**: 他エージェント経由の untrusted prompt で呼ばれ得るため、FS 境界を OS 強制で残す方針。

## レビュー反映（`/review`: security + code）

- **Critical**: Step 3.5 のファイル選択を `find | xargs ls -t` → NUL 区切り `while read -d ''` + `-nt` ループに変更（空入力での CWD 誤検知・スペース入りパス・GNU 専用構文を回避）
- **High**: マーカーパスを `RUN_ID` で一意化（並列実行競合の解消）
- cp の exit code 検証を追加

## 変更ファイル

- `packages/image-generation/agents/image-generator.md`（正本）+ 生成物（`.claude/agents/`, `.claude/skills/`, `.agents/skills/`）
- `facets/instructions/image-gen.md`, `packages/image-generation/README.md`
- `docs/adr/ADR-20260605-023.md`（Update 2026-06-17 追記）
- `CHANGELOG.md`（Unreleased: Fixed）

## 検証状況

- ✅ sandbox フラグの有効性: app-server 起動・backend 到達を実機確認（`Operation not permitted` 消滅）
- ✅ Step 3.5 bash ロジックを shell 実機で成功/失敗両ケース検証
- ✅ 全テスト 1415 passed
- ⚠️ **end-to-end の実画像生成は未検証**（ChatGPT 利用上限に到達、リセット後に要確認）。マージ前に `/image-gen` 1回実行で最終確認推奨

🤖 Generated with [Claude Code](https://claude.com/claude-code)