### PR TITLE
fix(quality-gates): failure_detector 適用でパイプマスク誤検知を修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **quality-gates のパイプマスク誤検知を修正（Issue #83）**: `quality_gate` イベントの `passed` 判定を `exit_code == 0` 単独から `failure_detector.analyze` の 2 段判定（exit_code + 出力パターン）へ統一。`pytest ... | tail -30` のようにパイプで終了コードがマスクされた失敗を `passed: false` と正しく記録し、`block_on_failed_test` 有効時はブロックする
+  - `post-test-analysis.py` の独自 `is_test_failure()` を削除し `packages/core/hooks/failure_detector.py` に一本化（検知ロジックの重複解消）。`extract_failure_summary` は存続
+  - `emit_quality_gate_event` は呼び出し側が導出した `gate_passed` を受け取る形に変更。payload キー（command/exit_code/passed/output_excerpt/blocking）は不変で後方互換。検知根拠を示す `detected_by`（`exit_code` / `output_pattern`）を任意で追記
 - **`/image-gen` スキルの画像生成失敗を修正（codex 0.140.0 対応・実機 E2E 検証済）**: codex-cli 0.140.0 への更新で `image-generator` エージェントの呼び出し契約が壊れていた問題を修正。実機の生成検証で原因を特定し対処した（赤リンゴ画像の出力まで確認）
   - **保存回帰の解決（`--enable imagegenext` 必須）**: codex 0.140.0 の `exec` モードは built-in `image_gen` の画像を**ディスクに保存しなくなっていた**（`image_generation_end` イベントから `saved_path` キーが消失。画像は base64 で返るのみ）。0.137.0 からの回帰で、`--enable imagegenext` フラグを付けると保存が復活する。これが無いと `~/.codex/generated_images/` は空のままで、エージェントが過去の画像を誤って掴む（虚偽成功）原因になっていた
   - **保存ファイル名の変化に追従**: imagegenext 有効時の保存名は `ig_*.png` ではなく `call_*.png`。鮮度ガードの検索を両パターン対応（`\( -name 'call_*.png' -o -name 'ig_*.png' \)`）に更新

--- a/packages/quality-gates/hooks/post-test-analysis.py
+++ b/packages/quality-gates/hooks/post-test-analysis.py
@@ -39,6 +39,7 @@ from event_logger import (  # noqa: E402
     load_trace_state,
     resolve_project_root_from_hook_data,
 )
+from failure_detector import analyze  # noqa: E402
 from hook_common import (  # noqa: E402
     DEFAULT_CODEX_FLAGS,
     DEFAULT_CODEX_MODEL,
@@ -70,27 +71,6 @@ def is_test_command(command: str) -> bool:
     """Check if the command is a test command."""
     command_lower = command.lower()
     return any(re.search(pattern, command_lower) for pattern in TEST_COMMAND_PATTERNS)
-
-
-def is_test_failure(exit_code: int, output: str) -> bool:
-    """Check if the test run failed."""
-    if exit_code != 0:
-        return True
-
-    # Check output for failure indicators
-    failure_indicators = [
-        "FAILED",
-        "FAIL:",
-        "failed",
-        "Error:",
-        "error:",
-        "AssertionError",
-        "TypeError",
-        "ValueError",
-        "test failed",
-        "tests failed",
-    ]
-    return any(indicator in output for indicator in failure_indicators)
 
 
 def extract_failure_summary(output: str) -> str:
@@ -169,9 +149,15 @@ def emit_quality_gate_event(
     *,
     command: str,
     exit_code: int,
+    gate_passed: bool,
     output: str,
+    detected_by: str | None = None,
 ) -> bool:
     """品質ゲート結果を audit イベントログに記録する。
+
+    `gate_passed` は failure_detector.analyze による 2 段判定の結果を
+    呼び出し側が導出して渡す。`exit_code` は payload 記録用に保持する
+    （パイプで終了コードがマスクされても出力パターンで失敗を検知できる）。
 
     Returns:
         `block_on_failed_test` によりブロックすべき場合は True。
@@ -182,18 +168,21 @@ def emit_quality_gate_event(
         return False
 
     trace = load_trace_state(project_dir=project_dir)
-    gate_passed = exit_code == 0
     blocking = bool(quality_gate.get("block_on_failed_test", False)) and not gate_passed
+
+    payload = {
+        "command": command[:200],
+        "exit_code": exit_code,
+        "passed": gate_passed,
+        "output_excerpt": output[:200] if output else "",
+        "blocking": blocking,
+    }
+    if detected_by is not None:
+        payload["detected_by"] = detected_by
 
     emit_event(
         "quality_gate",
-        {
-            "command": command[:200],
-            "exit_code": exit_code,
-            "passed": gate_passed,
-            "output_excerpt": output[:200] if output else "",
-            "blocking": blocking,
-        },
+        payload,
         session_id=str(data.get("session_id") or ""),
         tid=trace.get("tid", ""),
         project_dir=project_dir,
@@ -233,8 +222,12 @@ def main():
         exit_code = tool_response.get("exit_code", 0)
         output = tool_response.get("stdout", "") or tool_response.get("content", "")
 
-        analysis_failed = is_test_failure(exit_code, output)
-        gate_passed = exit_code == 0
+        # failure_detector で 2 段判定（exit_code + 出力パターン）に統一する。
+        # パイプで exit code がマスクされた失敗も output パターンで検知できる。
+        failure = analyze("Bash", tool_input, tool_response)
+        gate_passed = failure is None
+        analysis_failed = not gate_passed
+        detected_by = failure.get("detected_by") if failure else None
 
         # Record test result to shared state (success resets counters)
         record_test_result(command, gate_passed)
@@ -242,12 +235,17 @@ def main():
             data,
             command=command,
             exit_code=exit_code,
+            gate_passed=gate_passed,
             output=output,
+            detected_by=detected_by,
         )
 
         if blocking:
+            # detected_by を併記する。パイプマスク失敗（exit_code=0 でも
+            # 出力パターンで検知）の場合にブロック理由を判別できるようにする。
             print(
-                f"[quality-gates] quality gate blocked: test failed (exit_code={exit_code})",
+                f"[quality-gates] quality gate blocked: test failed "
+                f"(exit_code={exit_code}, detected_by={detected_by})",
                 file=sys.stderr,
             )
             sys.exit(2)

--- a/packages/quality-gates/tests/test_post_test_analysis.py
+++ b/packages/quality-gates/tests/test_post_test_analysis.py
@@ -49,16 +49,36 @@ def test_is_test_command_ignores_non_test_commands(command: str) -> None:
     assert not post_test_analysis.is_test_command(command)
 
 
-def test_is_test_failure_true_when_exit_code_nonzero() -> None:
-    assert post_test_analysis.is_test_failure(1, "all good")
+def test_analyze_detects_failure_on_nonzero_exit() -> None:
+    """終了コードが非ゼロなら失敗（最も信頼できる根拠）。"""
+    failure = post_test_analysis.analyze(
+        "Bash",
+        {"command": "pytest -q"},
+        {"exit_code": 1, "stdout": "1 failed in 0.12s"},
+    )
+    assert failure is not None
+    assert failure["detected_by"] == "exit_code"
 
 
-def test_is_test_failure_true_when_output_contains_failure_indicator() -> None:
-    assert post_test_analysis.is_test_failure(0, "2 tests FAILED")
+def test_analyze_detects_failure_on_output_marker_when_exit_code_masked() -> None:
+    """パイプで exit code がマスクされても出力パターンで失敗を検知する。"""
+    failure = post_test_analysis.analyze(
+        "Bash",
+        {"command": "pytest -q | tail -30"},
+        {"exit_code": 0, "stdout": "FAILED tests/test_x.py::test_y\n1 failed in 0.30s"},
+    )
+    assert failure is not None
+    assert failure["detected_by"] == "output_pattern"
 
 
-def test_is_test_failure_false_for_successful_output() -> None:
-    assert not post_test_analysis.is_test_failure(0, "12 passed")
+def test_analyze_returns_none_for_successful_output() -> None:
+    """実 pytest の成功出力では失敗としない。"""
+    failure = post_test_analysis.analyze(
+        "Bash",
+        {"command": "pytest -q"},
+        {"exit_code": 0, "stdout": "12 passed in 0.45s"},
+    )
+    assert failure is None
 
 
 def test_extract_failure_summary_returns_top_3_lines() -> None:
@@ -167,7 +187,9 @@ def test_emit_quality_gate_event_records_audit_event(monkeypatch: pytest.MonkeyP
         },
         command="pytest -q",
         exit_code=1,
+        gate_passed=False,
         output="FAILED test_example.py::test_case",
+        detected_by="exit_code",
     )
 
     assert blocking is False
@@ -176,6 +198,7 @@ def test_emit_quality_gate_event_records_audit_event(monkeypatch: pytest.MonkeyP
     assert captured["payload"]["exit_code"] == 1
     assert captured["payload"]["passed"] is False
     assert captured["payload"]["blocking"] is False
+    assert captured["payload"]["detected_by"] == "exit_code"
     assert captured["kwargs"]["session_id"] == "sid-1"
     assert captured["kwargs"]["tid"] == "tid-123"
 
@@ -200,15 +223,22 @@ def test_emit_quality_gate_event_returns_blocking_when_configured(
         {"session_id": "sid-1", "cwd": "/project"},
         command="pytest -q",
         exit_code=1,
+        gate_passed=False,
         output="FAILED",
     )
 
     assert blocking is True
 
 
-def test_emit_quality_gate_event_uses_exit_code_for_success_even_with_error_text(
+def test_emit_quality_gate_event_records_failure_when_exit_code_masked(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """パイプマスク回帰: exit_code=0 でも gate_passed=False なら failed 記録 + ブロック。
+
+    `pytest ... | tail -30` のようにパイプで終了コードがマスクされた失敗を、
+    failure_detector が出力パターンで検知し gate_passed=False を導出する。
+    その結果が payload に passed:false / blocking:true として記録されることを保証する。
+    """
     captured: dict = {}
 
     monkeypatch.setattr(
@@ -232,12 +262,34 @@ def test_emit_quality_gate_event_uses_exit_code_for_success_even_with_error_text
 
     blocking = post_test_analysis.emit_quality_gate_event(
         {"session_id": "sid-1", "cwd": "/project"},
-        command="pytest -q",
+        command="pytest -q | tail -30",
         exit_code=0,
-        output="ValueError: expected output marker",
+        gate_passed=False,
+        output="FAILED tests/test_x.py::test_y\n1 failed in 0.30s",
+        detected_by="output_pattern",
     )
 
-    assert blocking is False
+    assert blocking is True
     assert captured["type"] == "quality_gate"
-    assert captured["payload"]["passed"] is True
-    assert captured["payload"]["blocking"] is False
+    assert captured["payload"]["exit_code"] == 0
+    assert captured["payload"]["passed"] is False
+    assert captured["payload"]["blocking"] is True
+    assert captured["payload"]["detected_by"] == "output_pattern"
+
+
+def test_pipe_masked_failure_flow_derives_failed_gate_and_fires_suggestion() -> None:
+    """パイプマスク回帰（フロー）: exit_code=0 + "1 failed" → gate_passed=False。
+
+    main() が `analyze` から導出する gate_passed / analysis_failed を直接検証する。
+    analysis_failed=True は Codex debug suggestion 発火条件（非ブロック時）に一致する。
+    """
+    tool_input = {"command": "pytest -q | tail -30"}
+    tool_response = {"exit_code": 0, "stdout": "FAILED tests/test_x.py::test_y\n1 failed in 0.3s"}
+
+    failure = post_test_analysis.analyze("Bash", tool_input, tool_response)
+    gate_passed = failure is None
+    analysis_failed = not gate_passed
+
+    assert gate_passed is False
+    assert analysis_failed is True
+    assert failure["detected_by"] == "output_pattern"

--- a/tests/unit/test_quality_gates_hooks.py
+++ b/tests/unit/test_quality_gates_hooks.py
@@ -230,6 +230,7 @@ class TestPostTestAnalysis:
             {"session_id": "sid-1", "cwd": "/project"},
             command="pytest -q",
             exit_code=1,
+            gate_passed=False,
             output="FAILED",
         )
 


### PR DESCRIPTION
Closes #83

## Summary

- `quality_gate` イベントの `passed` 判定を `exit_code == 0` 単独から `failure_detector.analyze` の 2 段判定（exit_code + 出力パターン）へ統一
- `pytest ... | tail -30` のようにパイプで終了コードがマスクされた失敗を `passed: false` と正しく記録し、`block_on_failed_test` 有効時はブロック
- 独自 `is_test_failure()` を削除し `failure_detector` に一本化（`extract_failure_summary` は存続）
- `emit_quality_gate_event` は呼び出し側が導出した `gate_passed` を受け取る形に変更。payload 既存キー（command/exit_code/passed/output_excerpt/blocking）は不変で後方互換、検知根拠 `detected_by` を任意追記
- ブロック時 stderr に `detected_by` を併記しパイプマスク要因を可視化

## Testing

- [x] テスト実施済み: `AI_ORCHESTRA_DIR=$PWD pytest -q`（全体 1414 passed / 19 skipped）
- 変更パス: `analyze` 統合（main 系 + flow テスト）、`emit_quality_gate_event`（detected_by アサート・pipe-masked failure・blocking）をカバー

## Release Note

- ユーザー向け変更点: パイプで exit code がマスクされたテスト失敗を quality-gate が正しく失敗として記録・ブロックするようになった
- `CHANGELOG.md` 更新: 済（`Unreleased` の Fixed に Issue #83 エントリ追加）

## Checklist

- [x] PR タイトルが GitHub Release にそのまま載っても読める
- [x] 適切なラベルを付けた (`bug` / `refactor`)
- [x] ユーザー向け変更があるため `CHANGELOG.md` の `Unreleased` を更新した

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **品質改善**
  * 品質ゲートの失敗検出ロジックを統一し、より正確な検出結果を記録するようになりました。
  * 品質ゲートイベントに検出方法の詳細情報を追加し、監査ログの充実度が向上しました。

* **テスト**
  * テストスイートを拡充し、パイプマスク時の失敗検出を含む複数のシナリオをカバーするようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->