### PR TITLE
docs: README に設計思想（Prompt/Context/Harness + 整合性 CoDD）節を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,27 @@
 
 Claude Code用のマルチエージェントオーケストレーションシステム
 
+## 設計思想
+
+AI Orchestra は AI コーディングの実行基盤を 3 つの層で組み立て、さらに「変更しても壊れない」ための整合性層を加えた 4 層で捉える。
+
+| 層                    | 役割                     | AI Orchestra での実体                                                                                                    |
+| --------------------- | ------------------------ | ------------------------------------------------------------------------------------------------------------------------ |
+| **Prompt**            | 何を指示するか           | facets（policies / instructions / output-contracts）から合成する Skill・Rule                                             |
+| **Context**           | 何を踏まえるか           | `CLAUDE.md` / `AGENTS.md` テンプレート、config の階層上書き、`.claude/context/` のセッション間共有                       |
+| **Harness**           | どう実行するか           | hooks、agent-routing（28 エージェント）、packages 配布、外部 CLI（Codex / Antigravity）協調                              |
+| **Coherence（CoDD）** | 変更が入っても整合を保つ | `packages/codd`：各ドキュメントの `codd:` フロントマターで依存を宣言し、`scan` で依存グラフ構築・`validate` で不整合検出 |
+
+最初の 3 層が「一度うまく動かす」ための基盤であるのに対し、**CoDD（Coherence-Driven Development / 整合性駆動開発）** は「要件や設計が変わったとき、波及先の成果物まで整合を保つ」ことを扱うレイヤー。AI Orchestra ではこれを独立パッケージ `packages/codd`（essential プリセット）として配布レールに載せ、導入先プロジェクトが生成するドキュメントまで整合性管理の対象にする。
+
+CoDD の中核は次の 3 点:
+
+- **依存グラフ構築** — ドキュメント先頭の `codd:` ブロックが依存を宣言し、`scan` がグラフ（`.claude/codd/graph.jsonl`）を組み立てる。
+- **変更影響分析** — 上流を変更したとき、どの下流に波及するかをグラフから辿る（Phase 1 はドリフト検出として素朴に、信頼度スコアによる本格分析は Phase 2）。
+- **整合性維持** — `validate` がリンク切れ・重複・循環・孤立・ドリフトを検出し、追従漏れをガードレールとして可視化する。
+
+> 本節は [CoDD の提唱記事](https://zenn.dev/shio_shoppaize/articles/shogun-codd-coherence) の概念を、AI Orchestra の用語（facet / hook / `packages/codd`・scan/validate）に合わせて再構成したもので、原文の転載ではない。実装の詳細は [整合性レイヤー設計](docs/design/codd-coherence-layer.md) と [要件: 整合性ガードレール](docs/requirements/coherence-guardrail.md) を参照。
+
 ## アーキテクチャ
 
 ![アーキテクチャ図](docs/assets/architecture.png)


### PR DESCRIPTION
Closes #32

## Summary

- README に「設計思想」節を新設し、AI Orchestra を **Prompt / Context / Harness** の 3 層に整合性層 **CoDD** を加えた 4 層として概念整理した
- 各層を AI Orchestra の実体に対応づけ（Prompt→facet、Context→テンプレート/config 階層/context-sharing、Harness→hooks/agent-routing/packages、Coherence→`packages/codd`）
- CoDD の中核 3 点（**依存グラフ構築 / 変更影響分析 / 整合性維持**）を AI Orchestra の文脈（`codd:` フロントマター・`scan`/`validate`・essential 配布）で明記
- 元記事と既存設計文書（`docs/design/codd-coherence-layer.md` / `docs/requirements/coherence-guardrail.md`）への導線を追加
- 原文の転載ではなく AI Orchestra の用語へ再構成した方針を明示

### スコープ方針
- 実装（`packages/codd`）は PR #99 で導入済みのため、本 PR は **概念フレーミングのドキュメント追加のみ**
- 既存設計文書との重複を避けるため、概念の入口を README に最小限で 1 節だけ追加（drift リスク最小化）
- README は codd scope 外のためフロントマター付与は不要

## Testing

- [ ] テスト実施済み
- [x] 未実施（理由: ドキュメント（README）のみの変更。リンク先 2 ファイルの実在は確認済み）

## Release Note

- ユーザー向け変更点: README に CoDD を含む設計思想の概念説明を追加
- `CHANGELOG.md` 更新: 不要（ドキュメントのみの変更のため、ユーザー判断でスキップ）

## Checklist

- [x] PR タイトルが GitHub Release にそのまま載っても読める
- [x] 適切なラベルを付けた (`documentation`)
- [x] ドキュメントのみの変更につき CHANGELOG 更新はスキップ（理由を明記）

🤖 Generated with [Claude Code](https://claude.com/claude-code)